### PR TITLE
Fix extension adding in "search_path" (Windows)

### DIFF
--- a/include/boost/process/detail/windows/search_path.hpp
+++ b/include/boost/process/detail/windows/search_path.hpp
@@ -31,10 +31,11 @@ inline boost::filesystem::path search_path(
 {
     for (const boost::filesystem::path & pp : path)
     {
-        auto p = pp / filename;
+        auto full = pp / filename;
         std::array<std::string, 4> extensions {{ "", ".exe", ".com", ".bat" }};
         for (boost::filesystem::path ext : extensions)
         {
+            auto p = full;
             p += ext;
             boost::system::error_code ec;
             bool file = boost::filesystem::is_regular_file(p, ec);


### PR DESCRIPTION
Original code checks for "program", "program.exe", "program.exe.com" and "program.exe.com.bat" instead of "program", "program.exe", "program.com" and "program.bat".
This change fixes this.