### PR TITLE
Restore wargs tests

### DIFF
--- a/include/boost/process/detail/windows/basic_cmd.hpp
+++ b/include/boost/process/detail/windows/basic_cmd.hpp
@@ -67,11 +67,25 @@ inline std::string build_args(const std::string & exe, std::vector<std::string> 
 inline std::wstring build_args(const std::wstring & exe, std::vector<std::wstring> && data)
 {
     std::wstring st = exe;
+
+    //put in quotes if it has spaces
+    {
+        boost::replace_all(st, L"\"", L"\\\"");
+
+        auto it = std::find(st.begin(), st.end(), L' ');
+
+        if (it != st.end())//contains spaces.
+        {
+            st.insert(st.begin(), L'"');
+            st += L'"';
+        }
+    }
+
     for (auto & arg : data)
     {
         boost::replace_all(arg, L"\"", L"\\\"");
 
-        auto it = std::find(arg.begin(), arg.end(), ' ');//contains space?
+        auto it = std::find(arg.begin(), arg.end(), L' ');//contains space?
         if (it != arg.end())//ok, contains spaces.
         {
             //the first one is put directly onto the output,

--- a/test/wargs_cmd.cpp
+++ b/test/wargs_cmd.cpp
@@ -40,7 +40,6 @@ BOOST_AUTO_TEST_CASE(args, *boost::unit_test::timeout(2))
     if (ec)
         std::cout << "EC: " << ec.message() << std::endl;
     BOOST_REQUIRE(!ec);
-    return ;
 
     std::string s;
 
@@ -87,7 +86,7 @@ BOOST_AUTO_TEST_CASE(cmd, *boost::unit_test::timeout(2))
         ec
     );
     BOOST_REQUIRE(!ec);
-    return ;
+
     std::string s;
 
     std::getline(is, s);


### PR DESCRIPTION
I independently stumbled across the unquoted wargs with spaces bug, and while fixing it, also found that the wargs unit test was 1/2 disabled. I discarded my fix and pulled from https://github.com/klemens-morgenstern/boost-process, then removed the return statements -- that's why both changes show up in this PR.