### PR TITLE
Respect WIFSIGNALED

### DIFF
--- a/include/boost/process/detail/posix/wait_for_exit.hpp
+++ b/include/boost/process/detail/posix/wait_for_exit.hpp
@@ -26,9 +26,11 @@ inline void wait(const child_handle &p, int & exit_code)
     do
     {
         ret = ::waitpid(p.pid, &status, 0);
-    } while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status)));
+    } while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
     if (ret == -1)
         boost::process::detail::throw_last_error("waitpid(2) failed");
+    if (WIFSIGNALED(status))
+        throw process_error(std::error_code(), "process terminated due to receipt of a signal");
      exit_code = status;
 }
 


### PR DESCRIPTION
This is making the library a little nicer. Consider this example:

    // child.cpp
    int main()
    {
      throw 0;
    }

    // parent.cpp
    #include <boost/process.hpp>
    int main()
    {
      boost::process::child("./child").wait();
    }`

In the current state, this will output the following:

     % ./parent
    libc++abi.dylib: terminating with uncaught exception of type int
    libc++abi.dylib: terminating with uncaught exception of type boost::process::process_error: waitpid(2) failed: No child processes
    zsh: abort      ./parent`

With this patch, you get this output instead

     % ./parent
    libc++abi.dylib: terminating with uncaught exception of type int
    libc++abi.dylib: terminating with uncaught exception of type boost::process::process_error: process terminated due to receipt of a signal
    zsh: abort      ./parent`

I want to point out again that this is only about making the library a little nicer, i.e., the patch is certainly not required. However, I spent a bit of time debugging my application and the error `waitpid(2) failed: No child processes` sent me down the wrong path in that process, so I think it's useful. :-)