### PR TITLE
fix uninitialized variable and close(-1) behavior

### DIFF
--- a/include/boost/process/detail/child_decl.hpp
+++ b/include/boost/process/detail/child_decl.hpp
@@ -103,7 +103,7 @@ public:
     {
         if (valid() && !_exited())
         {
-            int code; 
+            int code = -1;
             auto res = boost::process::detail::api::is_running(_child_handle, code);
             if (!res && !_exited())
                 _exit_status->store(code);

--- a/include/boost/process/detail/posix/basic_pipe.hpp
+++ b/include/boost/process/detail/posix/basic_pipe.hpp
@@ -105,8 +105,10 @@ public:
 
     void close()
     {
-        ::close(_source);
-        ::close(_sink);
+        if (_source != -1)
+            ::close(_source);
+        if (_sink != -1)
+            ::close(_sink);
         _source = -1;
         _sink   = -1;
     }


### PR DESCRIPTION
Valgrind complains about:

==18274== Conditional jump or move depends on uninitialised value(s)
==18274==    at 0x4E63291: boost::process::child::_exited() (child_decl.hpp:54)
==18274==    by 0x4E634B0: boost::process::child::~child() (child_decl.hpp:93)

==18274==  Uninitialised value was created by a stack allocation
==18274==    at 0x4E6351A: boost::process::child::running() (child_decl.hpp:102)

Line numbers refer to ver 1.65.1

Not sure what should be a proper fix for this. Initialize "code" as -1 for now.

Valgrind also complains about close(-1) in basic_pipe.hpp. Should not close if _sink or _source is -1.