### PR TITLE
Fix move assignment for child_decl

### DIFF
--- a/include/boost/process/detail/child_decl.hpp
+++ b/include/boost/process/detail/child_decl.hpp
@@ -79,6 +79,7 @@ public:
         _child_handle= std::move(lhs._child_handle);
         _exit_status = std::move(lhs._exit_status);
         _attached    = lhs._attached;
+        _terminated  = lhs._terminated;
         lhs._attached = false;
         return *this;
     };


### PR DESCRIPTION
_terminate field is now copied from the move assingment operator on
child. This fixes the issue that a child process could previously only
be terminated() once (even after reassignment).