### PR TITLE
Switch WINAPI calling convention macros to the replacements from Boost.WinAPI

### DIFF
--- a/include/boost/process/detail/windows/job_workaround.hpp
+++ b/include/boost/process/detail/windows/job_workaround.hpp
@@ -82,7 +82,7 @@ typedef struct _JOBOBJECT_EXTENDED_LIMIT_INFORMATION_ {
   _Out_opt_ LPDWORD            lpReturnLength
 );
  */
-typedef ::boost::winapi::BOOL_  ( WINAPI *query_information_job_object_p)(
+typedef ::boost::winapi::BOOL_  ( BOOST_WINAPI_WINAPI_CC *query_information_job_object_p)(
         ::boost::winapi::HANDLE_,
         JOBOBJECTINFOCLASS_,
         void *,
@@ -90,7 +90,7 @@ typedef ::boost::winapi::BOOL_  ( WINAPI *query_information_job_object_p)(
         ::boost::winapi::DWORD_ *);
 
 
-inline ::boost::winapi::BOOL_ WINAPI query_information_job_object(
+inline ::boost::winapi::BOOL_ BOOST_WINAPI_WINAPI_CC query_information_job_object(
         ::boost::winapi::HANDLE_ hJob,
         JOBOBJECTINFOCLASS_ JobObjectInfoClass,
         void * lpJobObjectInfo,
@@ -110,7 +110,7 @@ inline ::boost::winapi::BOOL_ WINAPI query_information_job_object(
   _In_ DWORD              cbJobObjectInfoLength
 );*/
 
-typedef ::boost::winapi::BOOL_  ( WINAPI *set_information_job_object_p)(
+typedef ::boost::winapi::BOOL_  ( BOOST_WINAPI_WINAPI_CC *set_information_job_object_p)(
         ::boost::winapi::HANDLE_,
         JOBOBJECTINFOCLASS_,
         void *,
@@ -118,7 +118,7 @@ typedef ::boost::winapi::BOOL_  ( WINAPI *set_information_job_object_p)(
 
 }
 
-inline ::boost::winapi::BOOL_ WINAPI set_information_job_object(
+inline ::boost::winapi::BOOL_ BOOST_WINAPI_WINAPI_CC set_information_job_object(
         ::boost::winapi::HANDLE_ hJob,
         JOBOBJECTINFOCLASS_ JobObjectInfoClass,
         void * lpJobObjectInfo,


### PR DESCRIPTION
WINAPI macro definition in Boost.WinAPI is deprecated as it may clash with the macro defined in Windows SDK.