### PR TITLE
removes boost::asio:: from example in doc

### DIFF
--- a/doc/extend.qbk
+++ b/doc/extend.qbk
@@ -5,7 +5,7 @@
 [def __on_success__ [memberref boost::process::extend::handler::on_success on_success]]
 [def __posix_executor__ [classref boost::process::extend::posix_executor ex::posix_executor]]
 [def __windows_executor__ [classref boost::process::extend::windows_executor ex::windows_executor]]
-[def io_service  [@http://www.boost.org/doc/libs/release/doc/html/boost_asio/reference/io_service.html boost::asio::io_service]]
+[def __io_service__  [@http://www.boost.org/doc/libs/release/doc/html/boost_asio/reference/io_service.html boost::asio::io_service]]
 [def __require_io_service__ [classref boost::process::extend::require_io_service ex::require_io_service]]
 [def __async_handler__ [classref boost::process::extend::async_handler ex::async_handler]]
 [def __get_io_service__ [funcref boost::process::extend::get_io_service ex::get_io_service]]
@@ -50,7 +50,7 @@ So let's start with a simple hello-world example, while we use a C++14 generic l
 using namespace boost::process;
 namespace ex = bp::extend;
 
-__child__ c("foo", ex::__on_success__=[](auto & exec) {std::cout << "hello world" << std::endl;});
+__child__ c("foo", __on_success__=[](auto & exec) {std::cout << "hello world" << std::endl;});
 ```
 
 Considering that lambda can also capture values, data can easily be shared between handlers. 
@@ -95,7 +95,7 @@ Every handler not implemented dafaults to [classref boost::process::extend::hand
 [section:async Asynchronous Functionality]
 
 Since `boost.process` provides an interface for [@http://www.boost.org/doc/libs/release/libs/asio/ boost.asio], 
-this functionality is also available for extensions. If the class needs the io_service for some reason, the following code will do that.
+this functionality is also available for extensions. If the class needs the __io_service__ for some reason, the following code will do that.
 
 ```
 struct async_foo : __handler__, __require_io_service__ 
@@ -103,7 +103,7 @@ struct async_foo : __handler__, __require_io_service__
     tempalte<typename Executor>
     void on_setup(Executor & exec)
     {
-        io_service & ios = __get_io_service__(exec.seq); //gives us a reference and a compiler error if not present.
+        __io_service__ & ios = __get_io_service__(exec.seq); //gives us a reference and a compiler error if not present.
         //do something with ios
     }
 };

--- a/doc/tutorial.qbk
+++ b/doc/tutorial.qbk
@@ -313,7 +313,7 @@ To make it even easier, you can use [@http://en.cppreference.com/w/cpp/thread/fu
 Now we will revisit our first example and read the compiler output asynchronously:
 
 ```
-boost::asio::io_service ios;
+io_service ios;
 
 std::future<std::string> data;
 


### PR DESCRIPTION
In an example `boost::asio::io_service ios;` is used like this and looks in the generated doc like `boost::asio::boost::asio::io_service ios;` This pull request removes `boost::asio::` from the example.