### PR TITLE
Guard against EINTR in basic_pipe

### DIFF
--- a/include/boost/process/detail/posix/basic_pipe.hpp
+++ b/include/boost/process/detail/posix/basic_pipe.hpp
@@ -82,18 +82,26 @@ public:
 
     int_type write(const char_type * data, int_type count)
     {
-        auto write_len = ::write(_sink, data, count * sizeof(char_type));
-        if (write_len == -1)
-            ::boost::process::detail::throw_last_error();
-
+        int_type write_len;
+        while ((write_len = ::write(_sink, data, count * sizeof(char_type))) == -1)
+        {
+            //Try again if interrupted
+            auto err = errno;
+            if (err != EINTR)
+                ::boost::process::detail::throw_last_error();
+        }
         return write_len;
     }
     int_type read(char_type * data, int_type count)
     {
-        auto read_len = ::read(_source, data, count * sizeof(char_type));
-        if (read_len == -1)
-            ::boost::process::detail::throw_last_error();
-
+        int_type read_len;
+        while ((read_len = ::read(_source, data, count * sizeof(char_type))) == -1)
+        {
+            //Try again if interrupted
+            auto err = errno;
+            if (err != EINTR)
+                ::boost::process::detail::throw_last_error();
+        }
         return read_len;
     }
 


### PR DESCRIPTION
Based on the code from executor.hpp, a signal can cause invoking a child process to fail because reading/writing the pipe was interrupted.