### PR TITLE
fix warning due to extra semi colon

### DIFF
--- a/include/boost/process/detail/posix/io_context_ref.hpp
+++ b/include/boost/process/detail/posix/io_context_ref.hpp
@@ -64,7 +64,7 @@ struct async_handler_collector
     void operator()(T & t) const
     {
         handlers.push_back(t.on_exit_handler(exec));
-    };
+    }
 };
 
 //Also set's up waiting for the exit, so it can close async stuff.

--- a/include/boost/process/detail/posix/on_exit.hpp
+++ b/include/boost/process/detail/posix/on_exit.hpp
@@ -27,7 +27,7 @@ struct on_exit_ : boost::process::detail::posix::async_handler
     {
         return handler;
 
-    };
+    }
 };
 
 


### PR DESCRIPTION
In file included from /home/ldco/boost/include/boost/process/detail/on_exit.hpp:12:0,
                 from /home/ldco/boost/include/boost/process/async.hpp:33,
                 from /home/ldco/boost/include/boost/process.hpp:23,
                 from /home/ldco/Projects/Teaching/Teaching/Boost/Process/Process1/src/main.cpp:7:
/home/ldco/boost/include/boost/process/detail/posix/on_exit.hpp:30:6: warning: extra ‘;’ [-Wpedantic]
     };
      ^
In file included from /home/ldco/boost/include/boost/process/async.hpp:42:0,
                 from /home/ldco/boost/include/boost/process.hpp:23,
                 from /home/ldco/Projects/Teaching/Teaching/Boost/Process/Process1/src/main.cpp:7:
/home/ldco/boost/include/boost/process/detail/posix/io_context_ref.hpp:67:6: warning: extra ‘;’ [-Wpedantic]
     };
      ^