### PR TITLE
Fix double quotes processing on Windows

### DIFF
--- a/include/boost/process/detail/windows/basic_cmd.hpp
+++ b/include/boost/process/detail/windows/basic_cmd.hpp
@@ -30,14 +30,17 @@ inline std::string build_args(const std::string & exe, std::vector<std::string> 
 {
     std::string st = exe;
 
-    //put in quotes if it has spaces
+    //put in quotes if it has spaces or double quotes
+    if(!exe.empty() && exe.front() != '"')
     {
-        boost::replace_all(st, "\"", "\\\"");
+        auto it = st.find_first_of(" \"");
 
-        auto it = std::find(st.begin(), st.end(), ' ');
-
-        if (it != st.end())//contains spaces.
+        if(it != st.npos)//contains spaces.
         {
+            // double existing quotes
+            boost::replace_all(st, "\"", "\"\"");
+
+            // surround with quotes
             st.insert(st.begin(), '"');
             st += '"';
         }
@@ -45,15 +48,18 @@ inline std::string build_args(const std::string & exe, std::vector<std::string> 
 
     for (auto & arg : data)
     {
-        boost::replace_all(arg, "\"", "\\\"");
-
-        auto it = std::find(arg.begin(), arg.end(), ' ');//contains space?
-        if (it != arg.end())//ok, contains spaces.
+        if(!arg.empty() && arg.front() != '"')
         {
-            //the first one is put directly onto the output,
-            //because then I don't have to copy the whole string
-            arg.insert(arg.begin(), '"');
-            arg += '"'; //thats the post one.
+            auto it = arg.find_first_of(" \"");//contains space or double quotes?
+            if(it != arg.npos)//yes
+            {
+                // double existing quotes
+                boost::replace_all(arg, "\"", "\"\"");
+
+                // surround with quotes
+                arg.insert(arg.begin(), '"');
+                arg += '"';
+            }
         }
 
         if (!st.empty())//first one does not need a preceeding space
@@ -68,30 +74,36 @@ inline std::wstring build_args(const std::wstring & exe, std::vector<std::wstrin
 {
     std::wstring st = exe;
 
-    //put in quotes if it has spaces
+    //put in quotes if it has spaces or double quotes
+    if(!exe.empty() && exe.front() != L'"')
     {
-        boost::replace_all(st, L"\"", L"\\\"");
+        auto it = st.find_first_of(L" \"");
 
-        auto it = std::find(st.begin(), st.end(), L' ');
-
-        if (it != st.end())//contains spaces.
+        if(it != st.npos)//contains spaces or double quotes.
         {
+            // double existing quotes
+            boost::replace_all(st, L"\"", L"\"\"");
+
+            // surround with quotes
             st.insert(st.begin(), L'"');
             st += L'"';
         }
     }
 
-    for (auto & arg : data)
+    for(auto & arg : data)
     {
-        boost::replace_all(arg, L"\"", L"\\\"");
-
-        auto it = std::find(arg.begin(), arg.end(), L' ');//contains space?
-        if (it != arg.end())//ok, contains spaces.
+        if(!arg.empty() && arg.front() != L'"')
         {
-            //the first one is put directly onto the output,
-            //because then I don't have to copy the whole string
-            arg.insert(arg.begin(), L'"');
-            arg += L'"'; //thats the post one.
+            auto it = arg.find_first_of(L" \"");//contains space or double quotes?
+            if(it != arg.npos)//yes
+            {
+                // double existing quotes
+                boost::replace_all(arg, L"\"", L"\"\"");
+
+                // surround with quotes
+                arg.insert(arg.begin(), L'"');
+                arg += '"';
+            }
         }
 
         if (!st.empty())//first one does not need a preceeding space


### PR DESCRIPTION
Fix double quotes processing on Windows:
- quotes should only be added when not already present
- quotes need to be used when an argument includes spaces or double quotes
- quotes inside an argument should be doubled (that's the way Windows does escaping)

Test:
`BOOST_ASSERT(bp::detail::windows::build_args("echo", {"\"1\"", "2 3", "4\"5", "6 \"7"}) == "echo \"1\" \"2 3\" \"4\"\"5\" \"6 \"\"7\"");
`