### PR TITLE
fixed hidden local variable

### DIFF
--- a/include/boost/process/detail/windows/search_path.hpp
+++ b/include/boost/process/detail/windows/search_path.hpp
@@ -60,14 +60,14 @@ inline boost::filesystem::path search_path(
         auto p = pp_ / filename;
         for (boost::filesystem::path ext : extensions)
         {
-            boost::filesystem::path pp = p;
-            pp += ext;
+            boost::filesystem::path pp_ext = p;
+            pp_ext += ext;
             boost::system::error_code ec;
-            bool file = boost::filesystem::is_regular_file(pp, ec);
+            bool file = boost::filesystem::is_regular_file(pp_ext, ec);
             if (!ec && file &&
-                ::boost::winapi::sh_get_file_info(pp.native().c_str(), 0, 0, 0, ::boost::winapi::SHGFI_EXETYPE_))
+                ::boost::winapi::sh_get_file_info(pp_ext.native().c_str(), 0, 0, 0, ::boost::winapi::SHGFI_EXETYPE_))
             {
-                return pp;
+                return pp_ext;
             }
         }
     }


### PR DESCRIPTION
Hi Boost Process maintainers,
while compiling under windows, I faced a C4456 warning in boost::process::detail::windows::search_path
( https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4456 ) as declaration of 'pp' hides previous local declaration. 

In order to fix this warning, I renamed the internal variable inside the for loop.
As we are compiling with "treat warning as error", we require this fix to be available in future releases of boost::process. 

Thanks for considering and best regards
Michael