### PR TITLE
Fix GCC9 warning

### DIFF
--- a/include/boost/process/environment.hpp
+++ b/include/boost/process/environment.hpp
@@ -44,7 +44,7 @@ struct const_entry
             bool operator()(char c)    const {return c == api::env_seperator<char>   ();}
         } s;
         boost::split(data, _data, s);
-        return std::move(data);
+        return data;
     }
     string_type to_string()              const
     {


### PR DESCRIPTION
warning: moving a local object in a return statement prevents copy elision