### PR TITLE
Fix C4189 and C4267 on MSVC

### DIFF
--- a/include/boost/process/detail/windows/handles.hpp
+++ b/include/boost/process/detail/windows/handles.hpp
@@ -34,11 +34,11 @@ inline std::vector<native_handle_type> get_handles(std::error_code & ec)
 
     ::boost::winapi::NTSTATUS_ nt_status = STATUS_INFO_LENGTH_MISMATCH_;
 
-    for (int cnt = 0;
+    for (;
            nt_status == STATUS_INFO_LENGTH_MISMATCH_;
            nt_status = workaround::nt_system_query_information(
                             workaround::SystemHandleInformation_,
-                            info_pointer, buffer.size(),
+                            info_pointer, static_cast<::boost::winapi::ULONG_>(buffer.size()),
                             NULL))
     {
         buffer.resize(buffer.size() * 2);


### PR DESCRIPTION
Fix the following warnings:

* warning C4189: 'cnt': local variable is initialized but not referenced
* warning C4267: 'argument' conversion from 'size_t' to 'boost::winapi::ULONG_', possible loss of data