### PR TITLE
Miscellaneous fixes related to POSIX environments

### DIFF
--- a/include/boost/process/detail/posix/environment.hpp
+++ b/include/boost/process/detail/posix/environment.hpp
@@ -294,7 +294,11 @@ std::vector<Char*> basic_environment_impl<Char>::_load_var(std::vector<std::basi
     ret.reserve(data.size() +1);
 
     for (auto & val : data)
+    {
+        if (val.empty())
+            val.push_back(0);
         ret.push_back(&val.front());
+    }
 
     ret.push_back(nullptr);
     return ret;

--- a/include/boost/process/detail/posix/environment.hpp
+++ b/include/boost/process/detail/posix/environment.hpp
@@ -94,7 +94,7 @@ public:
     native_environment_impl & operator=(native_environment_impl && ) = default;
     native_handle_type _env_impl = _impl.data();
 
-    native_handle_type native_handle() const {return environ;}
+    native_handle_type native_handle() const {return _env_impl;}
 };
 
 template<>

--- a/test/async_pipe.cpp
+++ b/test/async_pipe.cpp
@@ -96,8 +96,10 @@ BOOST_AUTO_TEST_CASE(move_pipe)
     bp::async_pipe ap{ios};
     BOOST_TEST_CHECKPOINT("First move");
     bp::async_pipe ap2{std::move(ap)};
+#if defined(BOOST_WINDOWS_API)
     BOOST_CHECK_EQUAL(ap.native_source(), ::boost::winapi::INVALID_HANDLE_VALUE_);
     BOOST_CHECK_EQUAL(ap.native_sink  (), ::boost::winapi::INVALID_HANDLE_VALUE_);
+#endif
 
     BOOST_TEST_CHECKPOINT("Second move");
     ap = std::move(ap2);

--- a/test/environment.cpp
+++ b/test/environment.cpp
@@ -118,6 +118,29 @@ BOOST_AUTO_TEST_CASE(compare,  *boost::unit_test::timeout(5))
     BOOST_TEST_PASSPOINT();
 }
 
+BOOST_AUTO_TEST_CASE(wcompare,  *boost::unit_test::timeout(5))
+{
+    auto nat = boost::this_process::wenvironment();
+    bp::wenvironment env = nat;
+
+    {
+        BOOST_CHECK_EQUAL(nat.size(), env.size());
+        auto ni = nat.begin();
+        auto ei = env.begin();
+
+        while ((ni != nat.end()) &&(ei != env.end()))
+        {
+            BOOST_CHECK_EQUAL(ni->get_name(),  ei->get_name());
+            BOOST_CHECK_EQUAL(ni->to_string(), ei->to_string());
+            ni++; ei++;
+        }
+    }
+
+    BOOST_TEST_PASSPOINT();
+    env.clear();
+    BOOST_TEST_PASSPOINT();
+}
+
 BOOST_AUTO_TEST_CASE(insert_remove,  *boost::unit_test::timeout(5))
 {
     bp::environment env(boost::this_process::environment());


### PR DESCRIPTION
Notably, directly assigning a `wnative_environment` to a `native_environment` now works with POSIX environments. Previously, it failed to compile.