### PR TITLE
Pass io_context in on_exit example

### DIFF
--- a/include/boost/process/async.hpp
+++ b/include/boost/process/async.hpp
@@ -109,10 +109,10 @@ with `function` being a callable object with the signature `(int, const std::err
 \code{.cpp}
 io_context ios;
 
-child c("ls", on_exit=[](int exit, const std::error_code& ec_in){});
+child c("ls", ios, on_exit=[](int exit, const std::error_code& ec_in){});
 
 std::future<int> exit_code;
-chlid c2("ls", on_exit=exit_code);
+chlid c2("ls", ios, on_exit=exit_code);
 
 \endcode
 


### PR DESCRIPTION
The description already states that an io_context needs to be passed. This change is adjusting the example accordingly.