### PR TITLE
fix unwanted virtual call bypass during destruction

### DIFF
--- a/include/boost/process/pipe.hpp
+++ b/include/boost/process/pipe.hpp
@@ -160,7 +160,7 @@ struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
         return *this;
     }
     ///Writes characters to the associated output sequence from the put area
-    int_type overflow(int_type ch = traits_type::eof()) override
+    int_type overflow(int_type ch = traits_type::eof()) final override
     {
         if (_pipe.is_open() && (ch != traits_type::eof()))
         {
@@ -188,7 +188,7 @@ struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
         return traits_type::eof();
     }
     ///Synchronizes the buffers with the associated character sequence
-    int sync() override { return this->_write_impl() ? 0 : -1; }
+    int sync() final override { return this->_write_impl() ? 0 : -1; }
 
     ///Reads characters from the associated input sequence to the get area
     int_type underflow() override


### PR DESCRIPTION
I just upgraded to the new boost version and clang-tidy detected this error.

These changes fix the problem/warning. I don't think that there is a case where the functions really are going to be overriden in a derived class.

```
/usr/include/boost/process/pipe.hpp:127:13: error: Call to virtual method 'basic_pipebuf::overflow' during destruction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall,-warnings-as-errors]
            overflow(Traits::eof());
            ^
/tmp/reproducer.cpp:44:12: note: Calling implicit destructor for 'basic_opstream<char, std::__1::char_traits<char>>'
    struct Data {
           ^
/tmp/reproducer.cpp:44:12: note: Calling '~basic_pipebuf'
/usr/include/boost/process/pipe.hpp:126:9: note: Taking true branch
        if (is_open())
        ^
/usr/include/boost/process/pipe.hpp:127:13: note: Call to virtual method 'basic_pipebuf::overflow' during destruction bypasses virtual dispatch
            overflow(Traits::eof());
            ^
/usr/include/boost/process/pipe.hpp:184:12: error: Call to virtual method 'basic_pipebuf::sync' during destruction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall,-warnings-as-errors]
           this->sync();
           ^
/tmp/reproducer.cpp:44:12: note: Calling implicit destructor for 'basic_opstream<char, std::__1::char_traits<char>>'
    struct Data {
           ^
/tmp/reproducer.cpp:44:12: note: Calling '~basic_pipebuf'
/usr/include/boost/process/pipe.hpp:126:9: note: Taking true branch
        if (is_open())
        ^
/usr/include/boost/process/pipe.hpp:127:13: note: Calling 'basic_pipebuf::overflow'
            overflow(Traits::eof());
            ^
/usr/include/boost/process/pipe.hpp:165:13: note: Left side of '&&' is true
        if (_pipe.is_open() && (ch != traits_type::eof()))
            ^
/usr/include/boost/process/pipe.hpp:165:9: note: Taking false branch
        if (_pipe.is_open() && (ch != traits_type::eof()))
        ^
/usr/include/boost/process/pipe.hpp:183:14: note: Taking true branch
        else if (ch == traits_type::eof())
             ^
/usr/include/boost/process/pipe.hpp:184:12: note: Call to virtual method 'basic_pipebuf::sync' during destruction bypasses virtual dispatch
           this->sync();
```
