### PR TITLE
Add the lambda declarator needed to disambiguate the multiple return …

### DIFF
--- a/include/boost/process/detail/posix/environment.hpp
+++ b/include/boost/process/detail/posix/environment.hpp
@@ -230,7 +230,7 @@ template<typename Char>
 inline auto basic_environment_impl<Char>::get(const string_type &id) -> string_type
 {
     auto itr = std::find_if(_data.begin(), _data.end(), 
-            [&](const string_type & st)
+            [&](const string_type & st) -> bool
             {
                 if (st.size() <= id.size())
                     return false;
@@ -250,7 +250,7 @@ template<typename Char>
 inline void basic_environment_impl<Char>::set(const string_type &id, const string_type &value)
 {
     auto itr = std::find_if(_data.begin(), _data.end(), 
-        [&](const string_type & st)
+        [&](const string_type & st) -> bool
         {
             if (st.size() <= id.size())
                 return false;
@@ -270,7 +270,7 @@ template<typename Char>
 inline void  basic_environment_impl<Char>::reset(const string_type &id)
 {
     auto itr = std::find_if(_data.begin(), _data.end(), 
-        [&](const string_type & st)
+        [&](const string_type & st) -> bool
         {
             if (st.size() <= id.size())
                 return false;


### PR DESCRIPTION
…values from these lambda functions as a bool. Before this change the return of a "false" was interpreted as an int, but the second return is a bool. This caused the following compile error when accessing environment variables under Xcode 11.4.1: Return type 'bool' must match previous return type 'int' when lambda expression has unspecified explicit return type