### PR TITLE
Added return *this in move assignment operator

### DIFF
--- a/include/boost/process/detail/windows/file_descriptor.hpp
+++ b/include/boost/process/detail/windows/file_descriptor.hpp
@@ -102,6 +102,7 @@ struct file_descriptor
         if (_handle != ::boost::winapi::INVALID_HANDLE_VALUE_)
             ::boost::winapi::CloseHandle(_handle);
         _handle = boost::exchange(other._handle, ::boost::winapi::INVALID_HANDLE_VALUE_);
+        return *this;
     }
 
     ~file_descriptor()


### PR DESCRIPTION
I caught this while compiling with clang 10.0.0 with `-Werror,-Wreturn-type`. I'm unsure if the lack of a return statement was intentional