### PR TITLE
Fix windows builds that don't include Windows.h

### DIFF
--- a/include/boost/process/detail/windows/handle_workaround.hpp
+++ b/include/boost/process/detail/windows/handle_workaround.hpp
@@ -198,20 +198,20 @@ typedef struct _OBJECT_TYPE_INFORMATION_ {
 
 
 /*
-__kernel_entry NTSTATUS NtQuerySystemInformation(
+NTSTATUS NtQuerySystemInformation(
   IN SYSTEM_INFORMATION_CLASS SystemInformationClass,
   OUT PVOID                   SystemInformation,
   IN ULONG                    SystemInformationLength,
   OUT PULONG                  ReturnLength
 );
  */
-typedef ::boost::winapi::NTSTATUS_ (__kernel_entry *nt_system_query_information_p )(
+typedef ::boost::winapi::NTSTATUS_ (*nt_system_query_information_p )(
         SYSTEM_INFORMATION_CLASS_,
         void *,
         ::boost::winapi::ULONG_,
         ::boost::winapi::PULONG_);
 /*
-__kernel_entry NTSYSCALLAPI NTSTATUS NtQueryObject(
+NTSYSCALLAPI NTSTATUS NtQueryObject(
   HANDLE                   Handle,
   OBJECT_INFORMATION_CLASS ObjectInformationClass,
   PVOID                    ObjectInformation,
@@ -220,7 +220,7 @@ __kernel_entry NTSYSCALLAPI NTSTATUS NtQueryObject(
 );
  */
 
-typedef ::boost::winapi::NTSTATUS_ (__kernel_entry *nt_query_object_p )(
+typedef ::boost::winapi::NTSTATUS_ (*nt_query_object_p )(
         ::boost::winapi::HANDLE_,
         OBJECT_INFORMATION_CLASS_,
         void *,

--- a/include/boost/process/detail/windows/handles.hpp
+++ b/include/boost/process/detail/windows/handles.hpp
@@ -136,7 +136,7 @@ struct limit_handles_ : handler_base_ext
                 [&](::boost::winapi::HANDLE_ handle)
                 {
                     auto itr = std::find(all_handles.begin(), all_handles .end(), handle);
-                    DWORD flags = 0u;
+                    ::boost::winapi::DWORD_ flags = 0u;
                     if (itr != all_handles.end())
                         *itr = ::boost::winapi::INVALID_HANDLE_VALUE_;
                     else if ((::boost::winapi::GetHandleInformation(*itr, &flags) != 0)


### PR DESCRIPTION
Removed __kernel_entry usage from Nt* function typedefs, is is part of SAL annoations, not neccessary for proper signature and calling convention

Replaced global DWORD with ::boost::winapi::DWORD_

Also should fix #96 (not verified, I use msvc, not mingw but error appears on the same line)