### PR TITLE
Return default locale on POSIX systems

### DIFF
--- a/include/boost/process/locale.hpp
+++ b/include/boost/process/locale.hpp
@@ -76,9 +76,8 @@ inline std::locale default_locale()
     std::locale global_loc = std::locale();
     return std::locale(global_loc, new std::codecvt_utf8<wchar_t>);
 # else  // Other POSIX
-    // ISO C calls std::locale("") "the locale-specific native environment", and this
-    // locale is the default for many POSIX-based operating systems such as Linux.
-    return std::locale("");
+    // Return a default locale object.
+    return std::locale();
 # endif
 }
 


### PR DESCRIPTION
The comment here is incorrect; an empty locale is not the correct
behavior here and will cause exceptions to be thrown in other code.
Instead a locale object with the default constructor should be
returned, not one created with an empty string. This is a known issue
which was originally reported here:

https://svn.boost.org/trac10/ticket/4688

The issue claims to have been fixed in 7bb19f9 (see also:
https://svn.boost.org/trac10/changeset/72855).

However, this only fixes the issue for FreeBSD and not other POSIX
platforms. This patch is based on the one originally submitted here:

https://svn.boost.org/trac10/attachment/ticket/4688/boost_filesystem.patch
