### PR TITLE
posix/executor: Don't modify ::environ

### DIFF
--- a/include/boost/process/detail/posix/executor.hpp
+++ b/include/boost/process/detail/posix/executor.hpp
@@ -279,9 +279,9 @@ class executor
 
             if ((e != nullptr) && (*e != nullptr))
             {
-                *e += 5; //the beginnig of the string contains "PATH="
                 std::vector<std::string> path;
-                boost::split(path, *e, boost::is_any_of(":"));
+                // Parse PATH value, skipping the "PATH=" in the front
+                boost::split(path, *e + 5, boost::is_any_of(":"));
 
                 for (const std::string & pp : path)
                 {

--- a/include/boost/process/detail/posix/executor.hpp
+++ b/include/boost/process/detail/posix/executor.hpp
@@ -273,15 +273,11 @@ class executor
         prepare_cmd_style_fn = exe;
         if ((prepare_cmd_style_fn.find('/') == std::string::npos) && ::access(prepare_cmd_style_fn.c_str(), X_OK))
         {
-            auto e = ::environ;
-            while ((e != nullptr) && (*e != nullptr) && !boost::starts_with(*e, "PATH="))
-                e++;
-
-            if ((e != nullptr) && (*e != nullptr))
+            const char *const path_value = ::getenv("PATH");
+            if (path_value)
             {
                 std::vector<std::string> path;
-                // Parse PATH value, skipping the "PATH=" in the front
-                boost::split(path, *e + 5, boost::is_any_of(":"));
+                boost::split(path, path_value, boost::is_any_of(":"));
 
                 for (const std::string & pp : path)
                 {


### PR DESCRIPTION
Modifying the PATH entry in the environ global variable causes future PATH variable lookups to fail. So do the same but without modifying ::environ (this is the solution originally suggested in issue #121).

(Found due to failing cmd_test unit test since commit 5329519)