### PR TITLE
async_pipe: Refactor opened/closed state handling, avoid assign(-1)

### DIFF
--- a/test/async_pipe.cpp
+++ b/test/async_pipe.cpp
@@ -94,8 +94,11 @@ BOOST_AUTO_TEST_CASE(move_pipe)
     asio::io_context ios;
 
     bp::async_pipe ap{ios};
+    BOOST_CHECK(ap.is_open());
     BOOST_TEST_CHECKPOINT("First move");
     bp::async_pipe ap2{std::move(ap)};
+    BOOST_CHECK(!ap.is_open());
+    BOOST_CHECK(ap2.is_open());
 #if defined(BOOST_WINDOWS_API)
     BOOST_CHECK_EQUAL(ap.native_source(), ::boost::winapi::INVALID_HANDLE_VALUE_);
     BOOST_CHECK_EQUAL(ap.native_sink  (), ::boost::winapi::INVALID_HANDLE_VALUE_);


### PR DESCRIPTION
The async_pipe move_pipe unit test failed (here on Linux):
```
fatal error: in "async/move_pipe": Throw location unknown (consider using BOOST_THROW_EXCEPTION)
Dynamic exception type: boost::wrapexcept<boost::system::system_error>
std::exception::what: assign: Bad file descriptor
```

This was caused by the `stream_descriptor.assign(-1)` calls in the async_pipe move constructor. strace shows that it's trying to call epoll_ctl(EPOLL_CTL_ADD) for the -1 fd, which fails with EBADF.

I don't know whether maybe this used to work with older asio versions, or on different systems, but either way, checking the opened/closed state instead of manually setting/checking for -1 seems like a good solution.

This patch also fixes some potential fd leaks from some open() and dup() calls in case of exceptions.