### PR TITLE
use post() instead dispatch() for async_await()

### DIFF
--- a/include/boost/process/detail/posix/sigchld_service.hpp
+++ b/include/boost/process/detail/posix/sigchld_service.hpp
@@ -7,7 +7,6 @@
 #ifndef BOOST_PROCESS_DETAIL_POSIX_SIGCHLD_SERVICE_HPP_
 #define BOOST_PROCESS_DETAIL_POSIX_SIGCHLD_SERVICE_HPP_
 
-#include <boost/asio/dispatch.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/strand.hpp>
@@ -40,7 +39,7 @@ public:
         SignalHandler, void(boost::system::error_code)> init{handler};
 
         auto & h = init.completion_handler;
-        boost::asio::dispatch(
+        boost::asio::post(
                 _strand,
                 [this, pid, h]
                 {
@@ -57,7 +56,7 @@ public:
                             _signal_set.async_wait(
                                     [this](const boost::system::error_code &ec, int)
                                     {
-                                        boost::asio::dispatch(_strand, [this, ec]{this->_handle_signal(ec);});
+                                        boost::asio::post(_strand, [this, ec]{this->_handle_signal(ec);});
                                     });
                         _receivers.emplace_back(pid, h);
                     }


### PR DESCRIPTION
- dispatch() might queue the completion handler or invoke it immediately
- this might result in problems if this code runs in  completion
  handlers like coroutines where you must resume an already running coroutine
- using post() solves this issue