### PR TITLE
Add include to extend.hpp for memory.

### DIFF
--- a/include/boost/process/extend.hpp
+++ b/include/boost/process/extend.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/process/detail/handler.hpp>
 #include <boost/process/detail/used_handles.hpp>
+#include <memory>
 
 #if defined(BOOST_WINDOWS_API)
 #include <boost/process/detail/windows/executor.hpp>


### PR DESCRIPTION
`extend.hpp` uses `std::shared_ptr` as a member of `posix_executor` but does not include it.