### PR TITLE
Update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -1,6 +1,6 @@
 {
   "key": "process",
-  "name": "process",
+  "name": "Process",
   "authors": [
     "Merino Vidal", "Ilya Sokolov", "Felipe Tanus", 
     "Jeff Flinn", "Thomas Jarosch", "Boris Schaeling", "Klemens D. Morgenstern"


### PR DESCRIPTION
To match the pattern other boost libraries are using, the "name" field is capitalized and corresponds to what is shown on boost.org.