### PR TITLE
Adjust documentation relative paths

### DIFF
--- a/doc/Jamfile.jam
+++ b/doc/Jamfile.jam
@@ -24,11 +24,12 @@ generators.register-standard common.copy : XML : XMLPROCESSWORKAROUND ;
 xmlprocessworkaround posix_pseudocode   : posix_pseudocode.xml   ; 
 xmlprocessworkaround windows_pseudocode : windows_pseudocode.xml ;
 
+path-constant INCLUDES : ../../.. ;
 
 doxygen autodoc
 :
-  ../../../boost/process.hpp
-  [ glob ../../../boost/process/*.hpp ]
+  $(INCLUDES)/boost/process.hpp
+  [ glob $(INCLUDES)/boost/process/*.hpp ]
 :
   <doxygen:param>EXCLUDE_SYMBOLS=BOOST_ASIO_INITFN_RESULT_TYPE
   <doxygen:param>PREDEFINED=BOOST_PROCESS_DOXYGEN
@@ -39,7 +40,6 @@ doxygen autodoc
   <dependency>windows_pseudocode
   <xsl:path>.
 ;
-
 
 
 boostbook standalone


### PR DESCRIPTION
The current Jamfile is counting on the git layout instead of the boost release layout to generate the documentation. We can check the links are now correct for the release layout with `b2 libs/process/doc` from the boost root directory. This PR adjusts the documentation Jamfile with a `path-constant` for the doxygen command. 

This is circumstantially not very problematic at many places in the documentation because the b2 glob command interprets paths relative to the Jamfile (see https://github.com/boostorg/utility/pull/86#issuecomment-989294010), but that's not the case for all commands in there. For instance, the links on the headers like "Header <boost/process/child.hpp>" in the current [reference page](https://www.boost.org/doc/libs/1_78_0/doc/html/process/reference.html) are broken. This PR should probably fix this problem.
