### PR TITLE
Avoid using boost::filesystem w/string conversions on Windows

### DIFF
--- a/include/boost/process/detail/windows/basic_cmd.hpp
+++ b/include/boost/process/detail/windows/basic_cmd.hpp
@@ -159,7 +159,10 @@ struct exe_cmd_init : handler_base_ext
         return exe_cmd_init<Char>(std::move(sh), std::move(args_));
     }
 
-    static std:: string get_shell(char)    {return shell(). string(codecvt()); }
+    static std:: string get_shell(char)    {
+        std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+        return converter.to_bytes(shell().wstring(codecvt()));
+    }
     static std::wstring get_shell(wchar_t) {return shell().wstring(codecvt());}
 
     static exe_cmd_init<Char> cmd_shell(string_type&& cmd)

--- a/include/boost/process/detail/windows/shell_path.hpp
+++ b/include/boost/process/detail/windows/shell_path.hpp
@@ -26,7 +26,7 @@ inline boost::process::filesystem::path shell_path()
         throw_last_error("GetSystemDirectory() failed");
 
     boost::process::filesystem::path p = sysdir;
-    return p / "cmd.exe";
+    return p += L"\\cmd.exe";
 }
 
 inline boost::process::filesystem::path shell_path(std::error_code &ec) noexcept
@@ -43,7 +43,7 @@ inline boost::process::filesystem::path shell_path(std::error_code &ec) noexcept
     {
         ec.clear();
         p = sysdir;
-        p /= "cmd.exe";
+        p += L"\\cmd.exe";
     }
     return p;
 }


### PR DESCRIPTION
Converting from wstring to string (or vice versa) with boost::filesystem requires Filesystem to be compiled. However if these conversions are avoided, then boost::filesystem will not be needed by downstream projects.

A project I am working on is trying to remove boost filesystem and we noticed that doing so results in a linker error when cross compiling to windows. The root cause was identified to be that boost process for Windows ends up using some conversion functions which require boost filesystem to be compiled. This patch resolved those issues for us.