### PR TITLE
fix: "GetHandleInformation" is not a member of "boost::winapi"

### DIFF
--- a/include/boost/process/detail/windows/handles.hpp
+++ b/include/boost/process/detail/windows/handles.hpp
@@ -11,6 +11,7 @@
 #include <boost/process/detail/windows/handle_workaround.hpp>
 #include <boost/process/detail/windows/handler.hpp>
 #include <boost/winapi/get_current_process_id.hpp>
+#include <boost/winapi/handle_info.hpp>
 
 namespace boost { namespace process { namespace detail {
 


### PR DESCRIPTION
Fixes https://github.com/boostorg/process/issues/183 and https://github.com/boostorg/process/issues/224