### PR TITLE
Update executor.hpp

### DIFF
--- a/include/boost/process/detail/posix/executor.hpp
+++ b/include/boost/process/detail/posix/executor.hpp
@@ -153,7 +153,7 @@ class executor
     {
         //I am the child
         const auto len = std::strlen(msg);
-        int data[2] = {ec.value(), len + 1};
+        int data[2] = {ec.value(), static_cast<int>(len + 1)};
 
         ::write(_pipe_sink, &data[0], sizeof(int) * 2);
         ::write(_pipe_sink, msg, len);


### PR DESCRIPTION
explicit cast to int to silence this: `error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'int' in initializer list [-Wc++11-narrowing]`