### PR TITLE
Remove superflous calls in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,11 @@
 cmake_minimum_required(VERSION 3.5...3.16)
 
 project(boost_process VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
-find_package(Boost REQUIRED iostreams program_options filesystem system thread)
 
 add_library(boost_process INTERFACE)
 add_library(Boost::process ALIAS boost_process)
 
 target_include_directories(boost_process INTERFACE include)
-include_directories(include)
 target_link_libraries(boost_process
   INTERFACE
     Boost::algorithm


### PR DESCRIPTION
The find_package is not required, as the dependencies are done using the superproject build
The include_directories is already there: target_include_directories

Partial revert of 610b337fa3bc82ecd19cd7baa6e90874f62c050f in #250 