### PR TITLE
Fix V2::EXT::CWD [SunOS]

### DIFF
--- a/include/boost/process/v2/ext/impl/cwd.ipp
+++ b/include/boost/process/v2/ext/impl/cwd.ipp
@@ -112,8 +112,15 @@ filesystem::path cwd(boost::process::v2::pid_type pid, boost::system::error_code
 
 filesystem::path cwd(boost::process::v2::pid_type pid, boost::system::error_code & ec)
 {
+#if (defined(__linux__) || defined(__ANDROID__))
     return filesystem::canonical(
-                filesystem::path("/proc") /  std::to_string(pid) / "cwd", ec);
+            filesystem::path("/proc") / std::to_string(pid) / "cwd", ec
+            );
+#elif defined(__sun)
+    return fileystem::canonical(
+            filesystem::path("/proc") / std::to_string(pid) / "path/cwd"
+            );
+#endif
 }
 
 #elif defined(__FreeBSD__)

--- a/include/boost/process/v2/ext/impl/cwd.ipp
+++ b/include/boost/process/v2/ext/impl/cwd.ipp
@@ -118,7 +118,7 @@ filesystem::path cwd(boost::process::v2::pid_type pid, boost::system::error_code
             );
 #elif defined(__sun)
     return fileystem::canonical(
-            filesystem::path("/proc") / std::to_string(pid) / "path/cwd"
+            filesystem::path("/proc") / std::to_string(pid) / "path/cwd", ec
             );
 #endif
 }

--- a/include/boost/process/v2/ext/impl/exe.ipp
+++ b/include/boost/process/v2/ext/impl/exe.ipp
@@ -133,7 +133,7 @@ filesystem::path exe(boost::process::v2::pid_type pid, boost::system::error_code
             );
 #elif defined(__sun)
     return fileystem::canonical(
-            filesystem::path("/proc") / std::to_string(pid) / "path/a.out"
+            filesystem::path("/proc") / std::to_string(pid) / "path/a.out", ec
             );
 #endif
 }


### PR DESCRIPTION
filesystem::canonical is basically the same thing as realpath on Unix-likes, which only resolves one symbolic link. If one symbolic link points to yet another symbolic link and so on and so forth, it will not resolve all symbolic links. It will only do one link for each call to canonical. On SunOS, unlike Linux, /proc/${pid}/cwd does not directly point to the literal current working directory of the given ${pid}. Instead, it will point to yet another symlink - /proc/${pid}/path/cwd which once you have followed that second link only then will you have the literal cwd path for the process id.