### PR TITLE
Fixes #111 (pipe_buf::close doesn't close)

### DIFF
--- a/include/boost/process/pipe.hpp
+++ b/include/boost/process/pipe.hpp
@@ -251,8 +251,16 @@ struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
     {
         if (!is_open())
             return nullptr;
-        overflow(Traits::eof());
-        return this;
+        try
+        {
+            overflow(Traits::eof());
+            _pipe.close();
+            return this;
+        } catch(...)
+        {
+            _pipe.close();
+            throw;
+        }
     }
 private:
     pipe_type _pipe;


### PR DESCRIPTION
In response to issue #111

This doesn't fundamentally change the behaviour, i.e. the destructor of `basic_pipe` (and by extension `basic_opstream` etc) will still throw when flushing to a peer that has closed.

However, it gives users of Boost Process a way to avoid this, by `close()`-ing the stream/buffer/pipe before the destructor runs and handling any exceptions there.

E.g.

```c++
bp::opstream _os;

~MySafeDtor() {
   try {
       _os.close();
   } catch(std::exception const& e) {
       // exception-safe logging here
   }

   assert(!_os.rdbuf()->is_open()); // without this patch, this assert fails, causing certain program termination later
}
```
