### PR TITLE
Set underline pipe capacity. Linux only. Issue - https://github.com/boostorg/process/issues/322

### DIFF
--- a/include/boost/process/detail/posix/basic_pipe.hpp
+++ b/include/boost/process/detail/posix/basic_pipe.hpp
@@ -120,6 +120,28 @@ public:
         _source = -1;
         _sink   = -1;
     }
+
+    #if !(defined(__NetBSD__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__MACH__))
+        int_type set_pipe_capacity(int_type capacity) 
+    {
+        if (!is_open())
+        {
+            return -1;
+        }
+        int_type fd = _source != -1 ? _source : _sink;
+
+        int_type return_value;
+        while(((return_value = fcntl(fd, F_SETPIPE_SZ, capacity)) == -1))
+        {
+            //Try again if interrupted
+            auto err = errno;
+            if (err != EINTR)
+                ::boost::process::detail::throw_last_error();
+        }
+        
+        return return_value;
+    }
+    #endif
 };
 
 template<class CharT, class Traits>

--- a/test/pipe.cpp
+++ b/test/pipe.cpp
@@ -370,5 +370,35 @@ BOOST_AUTO_TEST_CASE(stream_close_scope, *boost::unit_test::timeout(5))
     BOOST_CHECK_EQUAL(i, j);
 }
 
+#if !(defined(__NetBSD__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__MACH__))
+    
+    BOOST_AUTO_TEST_CASE(set_pipe_capacity_max, *boost::unit_test::timeout(5))
+    {
+        std::ifstream file("/proc/sys/fs/pipe-max-size");
+        std::string content;
+        std::getline(file, content);
+        file.close();
+        int max_capacity = std::stoi(content);
+
+        bp::pipe pipe;
+        int capacity = pipe.set_pipe_capacity_max();
+        BOOST_CHECK_EQUAL(capacity, max_capacity);
+    }
+
+    BOOST_AUTO_TEST_CASE(set_pipe_capacity, *boost::unit_test::timeout(5))
+    {
+        int min_capacity = 80000;
+        bp::pipe pipe;
+
+        int capacity = pipe.set_pipe_capacity(min_capacity);
+        BOOST_REQUIRE_NO_THROW(capacity >= min_capacity);
+
+        min_capacity = capacity + 10000;
+        capacity = pipe.set_pipe_capacity(min_capacity);
+        BOOST_REQUIRE_NO_THROW(capacity >= min_capacity);
+    }
+
+#endif
+
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Possible Solution to https://github.com/boostorg/process/issues/322.
Including unit tests. 

Please let me know if:
1) You prefer the API to be part of the bp::opstream/bp::ipstream. So users need to go into ip.pipe.set_pipe_capacity().
2) Is it ok I included <string> and <fstream>?   I saw you use them only in the unit tests. However because of the #if, I think it won't cause compilation errors. 
3) Would you like me to add it to the doc's?
4) When could it be pushed in?