### PR TITLE
Reap zombie after failed execv issue285

### DIFF
--- a/test/posix_specific.cpp
+++ b/test/posix_specific.cpp
@@ -103,6 +103,20 @@ BOOST_AUTO_TEST_CASE(execve_throw_on_error, *boost::unit_test::timeout(2))
     }
 }
 
+BOOST_AUTO_TEST_CASE(execve_throw_on_error_no_zombie, *boost::unit_test::timeout(3000))
+{
+    while(waitpid(-1, nullptr, WNOHANG) > 0); // Clean possible zombies from other tests.
+
+    try 
+    {
+ 	 	boost::process::child("doesnt-exist");
+         BOOST_CHECK(false);
+ 	}
+    catch(...){}
+
+     BOOST_CHECK(waitpid(-1, nullptr, WNOHANG) <= 0);
+}
+
 BOOST_AUTO_TEST_CASE(leak_test, *boost::unit_test::timeout(5))
 {
     using boost::unit_test::framework::master_test_suite;


### PR DESCRIPTION
**Fixing issue** - https://github.com/boostorg/process/issues/285

**What was the problem**: After a failed execve, the caller was suppose to call waitpid and reap the zombie that the fork created.
However an exception was thrown before waitpid was called. 
This caused the child fork to become a zombie. 

Running the following code:
![image](https://github.com/boostorg/process/assets/93097769/477613e3-41b1-4c45-953f-1cfdaf4f18c2)
Would result:
![image](https://github.com/boostorg/process/assets/93097769/b91936b2-49d5-40f7-8c61-43ed340f0fd0)

**What I did**:
1) Extracting set_error() out of _read_error(). set_error() throws the exception, and is a big side effect for a function with the name of _read_error(). 
2) Calling set_error() Only after the waitpid. 
3) Attempting to call waitpid() twice, with a sleep between (if needed). The first waitpid may suffer a race condition, as the child fork didn't exit yet. 
4) Unit test.