### PR TITLE
Fix compilation with -Wall and -Werror

### DIFF
--- a/include/boost/process/detail/posix/async_out.hpp
+++ b/include/boost/process/detail/posix/async_out.hpp
@@ -71,7 +71,7 @@ struct async_out_buffer : ::boost::process::detail::posix::handler_base_ext,
     }
 
     template <typename Executor>
-    inline void on_success(Executor &exec)
+    inline void on_success(Executor &)
     {
         auto  pipe              = this->pipe;
         boost::asio::async_read(*pipe, buf,


### PR DESCRIPTION
While compiling with gcc 11.4 using -Wall and -Werror, this warning stops the compilation:

build/_deps/boost-src/libs/process/include/boost/process/detail/posix/async_out.hpp:74:38: error: unused parameter ‘exec’ [-Werror=unused-parameter]
   74 |     inline void on_success(Executor &exec)
      |                            ~~~~~~~~~~^~~~
cc1plus: all warnings being treated as errors