### PR TITLE
Code typos fixes

### DIFF
--- a/doc/design.qbk
+++ b/doc/design.qbk
@@ -83,7 +83,7 @@ will be called on the respective events on process launching. The names are:
 As an example:
 
 ```
-child c("ls", on_setup([](){cout << "On Setup" << endl;});
+child c("ls", on_setup([](){cout << "On Setup" << endl;}));
 ```
 
 

--- a/doc/tutorial.qbk
+++ b/doc/tutorial.qbk
@@ -348,7 +348,7 @@ and use the following code, the `gcc` process will still run afterwards:
 
 ```
 bp::child c("make");
-if (!c.child_wait_for(std::chrono::seconds(10)) //give it 10 seconds
+if (!c.child_wait_for(std::chrono::seconds(10))) //give it 10 seconds
     c.child_terminate(); //then terminate
 ```
 
@@ -357,7 +357,7 @@ So in order to also terminate `gcc` we can use a group.
 ```
 bp::group g;
 bp::child c("make", g);
-if (!g.group_wait_for(std::chrono::seconds(10))
+if (!g.group_wait_for(std::chrono::seconds(10)))
     g.group_terminate();
     
 c.child_wait(); //to avoid a zombie process & get the exit code

--- a/doc/v2/env.qbk
+++ b/doc/v2/env.qbk
@@ -20,8 +20,8 @@ To note is the `find_executable` functions, which searches in an environment for
 
     std::unordered_map<environment::key, environment::value> my_env =
         {
-            {"SECRET", "THIS_IS_A_TEST"}
-            {"PATH", {"/bin", "/usr/bin"}
+            {"SECRET", "THIS_IS_A_TEST"},
+            {"PATH", {"/bin", "/usr/bin"}}
         };
 
     auto other_exe = environment::find_executable("g++", my_env);
@@ -35,10 +35,10 @@ The subprocess environment assignment follows the same constraints:
     asio::io_context ctx;
     std::unordered_map<environment::key, environment::value> my_env =
         {
-            {"SECRET", "THIS_IS_A_TEST"}
-            {"PATH", {"/bin", "/usr/bin"}
+            {"SECRET", "THIS_IS_A_TEST"},
+            {"PATH", {"/bin", "/usr/bin"}}
         };
-    auto exe = find_executable("g++"), my_env);
+    auto exe = find_executable("g++");
     process proc(ctx, exe, {"main.cpp"}, process_environment(my_env));
     process pro2(ctx, exe, {"test.cpp"}, process_environment(my_env));
 ```

--- a/doc/v2/quickstart.qbk
+++ b/doc/v2/quickstart.qbk
@@ -114,7 +114,6 @@ The async version supports cancellation and will forward cancellation types as f
                     if (!ec)
                         sig.emit(asio::cancellation_type::terminal); 
                 });
-            );
         });
 
 ```


### PR DESCRIPTION
@klemens-morgenstern , please recheck the [Subprocess environment](https://www.boost.org/doc/libs/1_83_0/doc/html/boost_process/v2.html#boost_process.v2.env.process_env) example again.

Looks like rows `process proc(ctx, exe, {"main.cpp"}, process_environment(my_env));` row still may not be compiled.