### PR TITLE
Reap zombie after failed execve. Issue 285 

### DIFF
--- a/test/posix_specific.cpp
+++ b/test/posix_specific.cpp
@@ -103,6 +103,25 @@ BOOST_AUTO_TEST_CASE(execve_throw_on_error, *boost::unit_test::timeout(2))
     }
 }
 
+BOOST_AUTO_TEST_CASE(execve_throw_on_error_no_zombie, *boost::unit_test::timeout(3))
+{
+    while(waitpid(-1, nullptr, WNOHANG) > 0); // Clean possible zombies from other tests.
+    
+    try 
+    {
+ 	 	boost::process::child("doesnt-exist");
+        BOOST_CHECK(false);
+ 	}
+    catch(bp::process_error &e)
+    {
+        BOOST_CHECK(e.code());
+        BOOST_CHECK_EQUAL(e.code().value(), ENOENT);
+    }
+    
+    BOOST_CHECK_EQUAL(waitpid(-1, nullptr, WNOHANG), -1);
+    BOOST_CHECK_EQUAL(errno, ECHILD);
+}
+
 BOOST_AUTO_TEST_CASE(leak_test, *boost::unit_test::timeout(5))
 {
     using boost::unit_test::framework::master_test_suite;


### PR DESCRIPTION
After @klemens-morgenstern logical comments on the latest [pull request](https://github.com/boostorg/process/pull/325).
I created this pull request and closed the previous one.

In order to fix the [issue #217](https://github.com/boostorg/process/issues/285) this pull request does:
1 - Extracts ` _set_error()` out of `_read_error()`.  The function  `_set_error()` throws an exception which causes the code to never get to the `waitpid()` that cleans a zombie process after it failed an execve. 
Now `_read_error()` only reads the error as its name implies, and `_set_error()` will be called only after the `waitpid()`

2 - After the first step, I faced a race condition between the `::waitpid(this->pid, nullptr, WNOHANG);` and the actual `_exit(EXIT_FAILURE);` of the process which failed the execve. The `::waitpid(this->pid, nullptr, WNOHANG);` was called some times before the `_exit(EXIT_FAILURE);`.
In order to fix this, I check what was the failure reason that I get from `_read_error(p.p[0]);` and set the `waitpid()` parameter according to it. 

3 - Added a unit test to check that the fix works. 