### PR TITLE
Silence compile warning on msvc

### DIFF
--- a/include/boost/process/pipe.hpp
+++ b/include/boost/process/pipe.hpp
@@ -122,13 +122,15 @@ struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
 
     ///Destructor -> writes the frest of the data
     ~basic_pipebuf()
-    try 
     {
-        if (basic_pipebuf::is_open())
-            basic_pipebuf::overflow(Traits::eof());
-    }
-    catch (process_error & )
-    {
+        try 
+        {
+            if (basic_pipebuf::is_open())
+                basic_pipebuf::overflow(Traits::eof());
+        }
+        catch (process_error & )
+        {
+        }
     }
 
     ///Move construct from a pipe.


### PR DESCRIPTION
Warning
```
1>StartProcess.cpp
1>C:\Program Files\boost_1_83_0\boost/process/pipe.hpp(132,5): warning C4297: 'boost::process::basic_pipebuf<char,std::char_traits<char>>::~basic_pipebuf': function assumed not to throw an exception but does
1>C:\Program Files\boost_1_83_0\boost/process/pipe.hpp(132,5): message : destructor or deallocator has a (possibly implicit) non-throwing exception specification
1>C:\Program Files\boost_1_83_0\boost/process/pipe.hpp(124,6): message : while compiling class template member function 'boost::process::basic_pipebuf<char,std::char_traits<char>>::~basic_pipebuf(void)'
1>C:\Program Files\boost_1_83_0\boost/process/pipe.hpp(304,42): message : see reference to class template instantiation 'boost::process::basic_pipebuf<char,std::char_traits<char>>' being compiled
1>C:\Users\shaur\Desktop\Sources\TrinityCore\src\common\Utilities\StartProcess.cpp(85,14): message : see reference to class template instantiation 'boost::process::basic_ipstream<char,std::char_traits<char>>' being compiled
```

cl.exe version
```
Microsoft (R) C/C++ Optimizing Compiler Version 19.37.32822 for x64
```