### PR TITLE
fix group_wait test in cmake build.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ process_standalone_test(pipe)
 
 function(process_sub_launch_test name )
     add_executable(boost_process_${name} ${name}.cpp)
-    target_link_libraries(boost_process_${name} Boost::process Boost::system Boost::filesystem Boost::thread Boost::unit_test_framework)
+    target_link_libraries(boost_process_${name} Boost::process Boost::system Boost::filesystem Boost::scope_exit Boost::thread Boost::unit_test_framework)
     add_test(NAME boost_process_${name} COMMAND $<TARGET_FILE:boost_process_${name}> $<TARGET_FILE:boost_process_sub_launch> )
 endfunction()
 


### PR DESCRIPTION
Ran into this error in a CMake build of the Git source with `-DBUILD_TESTING=ON`:
```
[ 46%] Building CXX object libs/process/test/CMakeFiles/boost_process_group_wait.dir/group_wait.cpp.o
In file included from /tmp/boost/libs/system/include/boost/system/error_category.hpp(11),
                 from /tmp/boost/libs/system/include/boost/system/error_code.hpp(14),
                 from /tmp/boost/libs/process/test/group_wait.cpp(15):
/tmp/boost/libs/system/include/boost/system/detail/error_category_impl.hpp(141): warning #2196: routine is both "inline" and "noinline"
  inline BOOST_NOINLINE error_category::operator std::error_category const & () const
         ^

/tmp/boost/libs/process/test/group_wait.cpp(19): catastrophic error: cannot open source file "/tmp/boost/libs/process/test/group_wait.cpp"
  #include <boost/scope_exit.hpp>
                                 ^

compilation aborted for /tmp/boost/libs/process/test/group_wait.cpp (code 4)
make[2]: *** [libs/process/test/CMakeFiles/boost_process_group_wait.dir/build.make:76: libs/process/test/CMakeFiles/boost_process_group_wait.dir/group_wait.cpp.o] Error 4
make[1]: *** [CMakeFiles/Makefile2:37090: libs/process/test/CMakeFiles/boost_process_group_wait.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

Not sure I added `Boost::scope_exit` in the right place, but this at least got the build working again for me.