### PR TITLE
native_environment_impl::get method bugfix for Windows wchar_t

### DIFF
--- a/include/boost/process/detail/windows/environment.hpp
+++ b/include/boost/process/detail/windows/environment.hpp
@@ -65,7 +65,7 @@ inline auto native_environment_impl<Char>::get(const pointer_type id) -> string_
     {
         auto err =  ::boost::winapi::GetLastError();
         if (err == ::boost::winapi::ERROR_ENVVAR_NOT_FOUND_)//well, then we consider that an empty value
-            return "";
+            return string_type();
         else
             throw process_error(std::error_code(err, std::system_category()),
                                "GetEnvironmentVariable() failed");


### PR DESCRIPTION
Issue description: for Windows using MSVC when get method is invoked using native_environment_impl<Char=wchar_t> object compilation error C2440 (conversion from const char[] to std::wstring) is invoked

Reproduction: https://godbolt.org/z/4rMbzPKE5
Proposed solution: change of return value to empty std::basic_string<Char> object

