### PR TITLE
v2: sync initial value for exit code with v1

### DIFF
--- a/include/boost/process/v2/exit_code.hpp
+++ b/include/boost/process/v2/exit_code.hpp
@@ -72,7 +72,11 @@ typedef int native_exit_code_type;
 
 namespace detail
 {
-constexpr native_exit_code_type still_active = 0x7f;
+constexpr native_exit_code_type still_active = 0x17f;
+static_assert(WIFSTOPPED(still_active), "Expected still_active to indicate WIFSTOPPED");
+static_assert(!WIFEXITED(still_active), "Expected still_active to not indicate WIFEXITED");
+static_assert(!WIFSIGNALED(still_active), "Expected still_active to not indicate WIFSIGNALED");
+static_assert(!WIFCONTINUED(still_active), "Expected still_active to not indicate WIFCONTINUED");
 }
 
 inline bool process_is_running(int code)


### PR DESCRIPTION
The initial value for the exit_code (0x7f) in v2 doesn't work with musl libc. Here WIFSIGNALED(0x7f) expands to a non-zero value:

http://git.musl-libc.org/cgit/musl/tree/include/sys/wait.h#n54