### PR TITLE
posix: pipe_out: fix merge conflict

### DIFF
--- a/include/boost/process/detail/posix/pipe_out.hpp
+++ b/include/boost/process/detail/posix/pipe_out.hpp
@@ -14,14 +14,24 @@
 #include <boost/process/pipe.hpp>
 #include <boost/process/detail/posix/handler.hpp>
 #include <unistd.h>
+#include <array>
+#include <boost/process/detail/used_handles.hpp>
 
 namespace boost { namespace process { namespace detail { namespace posix {
 
 template<int p1, int p2>
-struct pipe_out : handler_base_ext
+struct pipe_out : handler_base_ext, ::boost::process::detail::uses_handles
 {
     int sink;
     int source; //opposite end
+
+    std::array<int, 4> get_used_handles()
+    {
+        const auto pp1 = p1 != -1 ? p1 : p2;
+        const auto pp2 = p2 != -1 ? p2 : p1;
+
+        return {source, sink, pp1, pp2};
+    }
 
     pipe_out(int sink, int source) : sink(sink), source(source) {}
 


### PR DESCRIPTION
In commit cbaa913e3d73 ("Merge branch 'develop' into limit_fd"), there have been merge conflicts in two files. In pipe_out.hpp, a previous commit from the "limit_fd" branch f8c0dd4da58a ("prototype for limit_fd") had been eliminated during wrong conflict resolution.

The final result was, that file descriptors for stdout pipes were not preserved when using limit_handles.

Example:

boost::asio::io_context io_context;
bp::async_pipe my_stdin(io_context);
bp::async_pipe my_stdout(io_context);
bp::child my_child("/usr/bin/echo", "Hello world",
    bp::std_in  < my_stdin,  // preserved by limit_handles
    bp::std_out > my_stdout, // closed by limit_handles
    bp::std_err > stderr,    // preserved by limit_handles
    bp::limit_handles)

Fixes: cbaa913e3d73 ("Merge branch 'develop' into limit_fd")