### PR TITLE
posix: Fix exec error reporting with limit_handles

### DIFF
--- a/test/limit_fd.cpp
+++ b/test/limit_fd.cpp
@@ -193,3 +193,9 @@ BOOST_AUTO_TEST_CASE(limit_fd, *boost::unit_test::timeout(5))
 
     fclose(p);
 }
+
+BOOST_AUTO_TEST_CASE(limit_fd_does_not_break_error_reporting, *boost::unit_test::timeout(5))
+{
+    BOOST_CHECK_THROW(boost::process::system("/does/not/exist"), boost::process::process_error);
+    BOOST_CHECK_THROW(boost::process::system("/does/not/exist", boost::process::limit_handles), boost::process::process_error);
+}


### PR DESCRIPTION
Hi,

This pull request contains a fix for posix `limit_handles`: It looks like `_pipe_sink` (the internal pipe used for passing exec() errors from child to parent) must be assigned earlier, before `call_on_setup()` and `limit_fd_::on_setup()`, so `executor::get_used_handles()` can see it. Otherwise it will be closed when using `limit_handles`, despite commit 1a1d677d which added the `executor::get_used_handles()`.