### PR TITLE
posix: Fix pipe fd leak if redirecting both stdout and stderr

### DIFF
--- a/include/boost/process/detail/posix/pipe_out.hpp
+++ b/include/boost/process/detail/posix/pipe_out.hpp
@@ -91,6 +91,7 @@ void pipe_out<1,2>::on_exec_setup(Executor &e) const
          e.set_error(::boost::process::detail::get_last_error(), "dup2() failed");
     if ((sink != STDOUT_FILENO) && (sink != STDERR_FILENO))
         ::close(sink);
+    ::close(source);
 }
 
 class async_pipe;


### PR DESCRIPTION
Hi,

This pull request re-adds a close() call in posix pipe_out, which already existed before commit caa7b2fcc8. pipe_out should always close its fd for the read end of the pipe. It already did it when redirecting only stdout or only stderr, but it was missing for the third case where both stdout and stderr are redirected (`bp::std_out & bp::std_err > my_async_pipe`).

The second commit adds a unit test for this issue, hopefully it is useful, although I'm not sure if this style of test is okay.