### PR TITLE
posix: check glibc version for ::close_range function

### DIFF
--- a/include/boost/process/v2/posix/detail/close_handles.ipp
+++ b/include/boost/process/v2/posix/detail/close_handles.ipp
@@ -45,12 +45,26 @@ int fdwalk(int (*func)(void *, int), void *cd);
 
 #include <linux/version.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0)
+#ifdef __GLIBC__
 
+#include <gnu/libc-version.h>
+
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
+// on glibc we also must have ::close_range() wrapper around system call
+// if we're building on system with new kernel, BUT without this wrapper (old glibc) the build will be failed
+#define BOOST_PROCESS_V2_HAS_CLOSE_RANGE 1
+#endif // if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
+
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) // if no __GLIBC__ defined
+// we're not on glibc, so just check the version code
+#define BOOST_PROCESS_V2_HAS_CLOSE_RANGE 1
+
+#endif // ifdef __GLIBC__
+
+#ifdef BOOST_PROCESS_V2_HAS_CLOSE_RANGE
 // https://man7.org/linux/man-pages/man2/close_range.2.html
 #include <linux/close_range.h>
-#define BOOST_PROCESS_V2_HAS_CLOSE_RANGE 1 
-#else 
+#else
 
 #include <dirent.h>
 

--- a/include/boost/process/v2/posix/detail/close_handles.ipp
+++ b/include/boost/process/v2/posix/detail/close_handles.ipp
@@ -45,7 +45,9 @@ int fdwalk(int (*func)(void *, int), void *cd);
 
 #elif defined(__linux__) // elif defined(__sun)
 
-#include <linux/version.h>
+// define BOOST_PROCESS_V2_POSIX_FORCE_DISABLE_CLOSE_RANGE to force disable any usage of ::close_range()
+
+#include <sys/syscall.h>
 
 // All checks here are intended to check whether target system has ::close_range()
 // Note that this checks only valid on glibc. MUSL doens't have ::close_range() anyway. So we don't care about any
@@ -55,7 +57,7 @@ int fdwalk(int (*func)(void *, int), void *cd);
 // On glibc we also must have ::close_range() wrapper around system call.
 // If we're building on system with new kernel, BUT without this wrapper (old glibc) the build will be failed
 #include <gnu/libc-version.h>
-#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
+#if (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34) && !defined(BOOST_PROCESS_V2_POSIX_FORCE_DISABLE_CLOSE_RANGE)
 #define BOOST_PROCESS_V2_HAS_CLOSE_RANGE 1
 #endif // __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
 
@@ -63,7 +65,7 @@ int fdwalk(int (*func)(void *, int), void *cd);
 
 // glibc version doesn't meet version requirements or we're building with MUSL.
 // Just try to check linux version code. If system call is supported we'll use raw system call
-#if !defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#if !defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE) && defined(SYS_close_range) && !defined(BOOST_PROCESS_V2_POSIX_FORCE_DISABLE_CLOSE_RANGE)
 #define BOOST_PROCESS_V2_HAS_CLOSE_RANGE_SYSCALL 1
 #endif // if !defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
 

--- a/include/boost/process/v2/posix/detail/close_handles.ipp
+++ b/include/boost/process/v2/posix/detail/close_handles.ipp
@@ -14,7 +14,9 @@
 #include <boost/process/v2/detail/config.hpp>
 #include <boost/process/v2/detail/last_error.hpp>
 #include <boost/process/v2/posix/detail/close_handles.hpp>
-// linux has close_range since 5.19
+// linux has close_range since 5.9
+// see: https://man.archlinux.org/man/close_range.2.en#HISTORY
+//      https://elixir.bootlin.com/linux/v5.9/source/fs/open.c#L1318
 
 
 #if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__)
@@ -31,7 +33,7 @@
 #include <unistd.h>
 #define BOOST_PROCESS_V2_HAS_CLOSE_RANGE_AND_CLOSEFROM 1 
 
-#elif defined(__sun)
+#elif defined(__sun) // if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 
 /*https://docs.oracle.com/cd/E36784_01/html/E36874/closefrom-3c.html
 
@@ -41,36 +43,40 @@ int fdwalk(int (*func)(void *, int), void *cd);
 #include <stdlib.h>
 #define BOOST_PROCESS_V2_HAS_PDFORK 1 
 
-#elif defined(__linux__)
+#elif defined(__linux__) // elif defined(__sun)
 
 #include <linux/version.h>
 
-#ifdef __GLIBC__
+// All checks here are intended to check whether target system has ::close_range()
+// Note that this checks only valid on glibc. MUSL doens't have ::close_range() anyway. So we don't care about any
+// MUSL library macroses
+#if defined(__GLIBC__)
 
+// On glibc we also must have ::close_range() wrapper around system call.
+// If we're building on system with new kernel, BUT without this wrapper (old glibc) the build will be failed
 #include <gnu/libc-version.h>
-
 #if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
-// on glibc we also must have ::close_range() wrapper around system call
-// if we're building on system with new kernel, BUT without this wrapper (old glibc) the build will be failed
 #define BOOST_PROCESS_V2_HAS_CLOSE_RANGE 1
-#endif // if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
-
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) // if no __GLIBC__ defined
-// we're not on glibc, so just check the version code
-#define BOOST_PROCESS_V2_HAS_CLOSE_RANGE 1
+#endif // __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
 
 #endif // ifdef __GLIBC__
 
-#ifdef BOOST_PROCESS_V2_HAS_CLOSE_RANGE
+// glibc version doesn't meet version requirements or we're building with MUSL.
+// Just try to check linux version code. If system call is supported we'll use raw system call
+#if !defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#define BOOST_PROCESS_V2_HAS_CLOSE_RANGE_SYSCALL 1
+#endif // if !defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+
 // https://man7.org/linux/man-pages/man2/close_range.2.html
+#if defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE) || defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE_SYSCALL)
 #include <linux/close_range.h>
-#else
+#include <sys/syscall.h>
 
+#else // ifdef BOOST_PROCESS_V2_HAS_CLOSE_RANGE || defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE_SYSCALL)
 #include <dirent.h>
+#endif // BOOST_PROCESS_V2_HAS_CLOSE_RANGE || defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE_SYSCALL)
 
-#endif
-
-#else
+#else // elif defined(__linux__)
 
 #include <dirent.h>
 
@@ -157,6 +163,36 @@ void close_all(const std::vector<int> & whitelist, error_code & ec)
     }
     else
         ::close_range(0, std::numeric_limits<int>::max(), CLOSE_RANGE_UNSHARE);
+}
+
+#elif defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE_SYSCALL)
+
+// linux impl - whitelist must be ordered
+void close_all(const std::vector<int> & whitelist, error_code & ec)
+{
+    // https://patchwork.kernel.org/project/linux-fsdevel/cover/20200602204219.186620-1-christian.brauner@ubuntu.com/
+    //the most common scenario is whitelist = {0,1,2}
+    if (!whitelist.empty())
+    {
+        if (whitelist.front() != 0)
+            ::syscall(SYS_close_range, 0, whitelist.front() - 1, CLOSE_RANGE_UNSHARE);
+
+        for (std::size_t idx = 0u;
+             idx < (whitelist.size() - 1u);
+             idx++)
+        {
+            const auto mine = whitelist[idx];
+            const auto next = whitelist[idx + 1];
+            if ((mine + 1) != next && (mine != next))
+            {
+                ::syscall(SYS_close_range, mine + 1, next - 1, CLOSE_RANGE_UNSHARE);
+            }
+        }
+
+        ::syscall(SYS_close_range, whitelist.back() + 1, std::numeric_limits<int>::max(), CLOSE_RANGE_UNSHARE);
+    }
+    else
+        ::syscall(SYS_close_range, 0, std::numeric_limits<int>::max(), CLOSE_RANGE_UNSHARE);
 }
 
 #else

--- a/include/boost/process/v2/posix/detail/close_handles.ipp
+++ b/include/boost/process/v2/posix/detail/close_handles.ipp
@@ -100,7 +100,7 @@ namespace detail
 /*!
  * Just a convenient wrapper around raw system call or glibc function if present
  */
-int close_range_wrapper(unsigned int first, unsigned int last, unsigned int flags) {
+inline int close_range_wrapper(unsigned int first, unsigned int last, unsigned int flags) {
 #if defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE)
     return ::close_range(first, last, flags);
 #elif defined(BOOST_PROCESS_V2_HAS_CLOSE_RANGE_SYSCALL)


### PR DESCRIPTION
On old systems with old glibc, but new kernel (the common case is build in CI on ancient OS with old glibc for extended compatibility) there may not be `::close_range()` function. In this case build will fail.

To avoid that we should properly check not only linux kernel version, but glibc version too.

There is one another option to solve this issue is use raw system call with only checking kernel version, but it seems to me dirty solution.