### PR TITLE
Fix POSIX `process_stdio` move semantics

### DIFF
--- a/include/boost/process/v2/stdio.hpp
+++ b/include/boost/process/v2/stdio.hpp
@@ -164,6 +164,31 @@ struct process_io_binding
   }
 
   process_io_binding() = default;
+  process_io_binding(const process_io_binding &) = delete;
+  process_io_binding & operator=(const process_io_binding &) = delete;
+
+  process_io_binding(process_io_binding && other) noexcept
+          : fd(other.fd), fd_needs_closing(other.fd), ec(other.ec)
+  {
+    other.fd = target;
+    other.fd_needs_closing = false;
+    other.ec = {};
+  }
+
+  process_io_binding & operator=(process_io_binding && other) noexcept
+  {
+    if (fd_needs_closing)
+      ::close(fd);
+
+    fd = other.fd;
+    fd_needs_closing = other.fd_needs_closing;
+    ec = other.ec;
+
+    other.fd = target;
+    other.fd_needs_closing = false;
+    other.ec = {};
+    return *this;
+  }
 
   template<typename Stream>
   process_io_binding(Stream && str, decltype(std::declval<Stream>().native_handle()) = -1)


### PR DESCRIPTION
Fixes #448. Aside from adding the move operations, I've also added two test cases: one demonstrating implicit creation of pipes by `process_stdio` which was previously untested AFAICT, and one (regression) test specifically for the move semantics.

I'm curious if you'd also be open to making the members for `process_io_binding` private (on both platforms, actually)? `process_io_binding` has to maintain an invariant (whether `fd` needs to be closed) and leaving its members public allows external code to break that invariant. I'm not sure that your policy is towards breaking source compatibility in the `detail` namespace, so I have refrained from making that change.