### PR TITLE
Fix v1 tests after v2 became the default

### DIFF
--- a/test/v1/args_cmd.cpp
+++ b/test/v1/args_cmd.cpp
@@ -21,9 +21,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
-namespace bp = boost::process;
-
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(args, *boost::unit_test::timeout(2))
 {

--- a/test/v1/args_handling.cpp
+++ b/test/v1/args_handling.cpp
@@ -19,7 +19,7 @@
 #include <boost/process/v1/error.hpp>
 #include <boost/process/v1/child.hpp>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 BOOST_AUTO_TEST_CASE(implicit_args_fs_path)

--- a/test/v1/asio_no_deprecated.cpp
+++ b/test/v1/asio_no_deprecated.cpp
@@ -3,7 +3,30 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_ASIO_NO_DEPRECATED 1
-#include <boost/process.hpp>
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/async_pipe.hpp>
+#include <boost/process/v1/async_system.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/env.hpp>
+#include <boost/process/v1/environment.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/exception.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/extend.hpp>
+#include <boost/process/v1/filesystem.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/locale.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/shell.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#include <boost/process/v1/system.hpp>
+
 int main() {}
 
 #if defined(BOOST_POSIX_API)

--- a/test/v1/async.cpp
+++ b/test/v1/async.cpp
@@ -25,7 +25,7 @@
 
 using namespace std;
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 #if __APPLE__
 auto abort_sig = signal(SIGALRM, +[](int){std::terminate();});

--- a/test/v1/async_fut.cpp
+++ b/test/v1/async_fut.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_SUITE( async );
 
 using namespace std;
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(async_out_future, *boost::unit_test::timeout(2))
 {

--- a/test/v1/async_pipe.cpp
+++ b/test/v1/async_pipe.cpp
@@ -20,7 +20,7 @@
 #include <boost/asio/streambuf.hpp>
 
 using namespace std;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 namespace asio = boost::asio;
 
 BOOST_AUTO_TEST_SUITE( async );

--- a/test/v1/async_system_fail.cpp
+++ b/test/v1/async_system_fail.cpp
@@ -18,7 +18,7 @@
 #include <boost/process/v1/async_system.hpp>
 #include <system_error>
 
-namespace bp = boost::process;;
+namespace bp = boost::process::v1;
 
 void fail_func()
 {

--- a/test/v1/async_system_future.cpp
+++ b/test/v1/async_system_future.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 #include <array>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_SUITE( async );
 
 BOOST_AUTO_TEST_CASE(future, *boost::unit_test::timeout(15))

--- a/test/v1/async_system_stackful.cpp
+++ b/test/v1/async_system_stackful.cpp
@@ -27,7 +27,7 @@
 #include <array>
 BOOST_AUTO_TEST_SUITE( async );
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_CASE(stackful, *boost::unit_test::timeout(15))
 {
     using boost::unit_test::framework::master_test_suite;

--- a/test/v1/async_system_stackful_error.cpp
+++ b/test/v1/async_system_stackful_error.cpp
@@ -26,7 +26,7 @@
 #include <array>
 BOOST_AUTO_TEST_SUITE( async );
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_CASE(stackful, *boost::unit_test::timeout(15))
 {
     using boost::unit_test::framework::master_test_suite;

--- a/test/v1/async_system_stackful_except.cpp
+++ b/test/v1/async_system_stackful_except.cpp
@@ -26,7 +26,7 @@
 #include <array>
 BOOST_AUTO_TEST_SUITE( async );
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_CASE(stackful_except, *boost::unit_test::timeout(15))
 {
     using boost::unit_test::framework::master_test_suite;

--- a/test/v1/async_system_stackless.cpp
+++ b/test/v1/async_system_stackless.cpp
@@ -25,7 +25,7 @@
 #include <array>
 BOOST_AUTO_TEST_SUITE( async );
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_CASE(stackless, *boost::unit_test::timeout(15))
 {
     using boost::unit_test::framework::master_test_suite;

--- a/test/v1/bind_stderr.cpp
+++ b/test/v1/bind_stderr.cpp
@@ -39,7 +39,7 @@ typedef boost::asio::posix::stream_descriptor pipe_end;
 #endif
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_SUITE( bind_stderr );
 
 BOOST_AUTO_TEST_CASE(sync_io, *boost::unit_test::timeout(2))

--- a/test/v1/bind_stdin.cpp
+++ b/test/v1/bind_stdin.cpp
@@ -43,7 +43,7 @@ typedef boost::asio::posix::stream_descriptor pipe_end;
 
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(sync_io, *boost::unit_test::timeout(10))
 {

--- a/test/v1/bind_stdin_stdout.cpp
+++ b/test/v1/bind_stdin_stdout.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <iostream>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_SUITE( bind_stdin_stdout );
 
 BOOST_AUTO_TEST_CASE(sync_io, *boost::unit_test::timeout(10))

--- a/test/v1/bind_stdout.cpp
+++ b/test/v1/bind_stdout.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_SUITE( bind_stdout );
 
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(sync_io, *boost::unit_test::timeout(5))
 {

--- a/test/v1/bind_stdout_stderr.cpp
+++ b/test/v1/bind_stdout_stderr.cpp
@@ -34,7 +34,7 @@ typedef boost::asio::windows::stream_handle pipe_end;
 typedef boost::asio::posix::stream_descriptor pipe_end;
 #endif
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_SUITE( bind_stdout_stderr );
 

--- a/test/v1/close_stderr.cpp
+++ b/test/v1/close_stderr.cpp
@@ -22,7 +22,7 @@
 #   include <sys/wait.h>
 #endif
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 BOOST_AUTO_TEST_CASE(close_stderr)

--- a/test/v1/close_stdin.cpp
+++ b/test/v1/close_stdin.cpp
@@ -22,7 +22,7 @@
 #   include <sys/wait.h>
 #endif
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(close_stdin)
 {

--- a/test/v1/close_stdout.cpp
+++ b/test/v1/close_stdout.cpp
@@ -22,7 +22,7 @@
 #   include <sys/wait.h>
 #endif
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(close_stdout)
 {

--- a/test/v1/cmd_test.cpp
+++ b/test/v1/cmd_test.cpp
@@ -26,7 +26,7 @@
 #include <boost/system/error_code.hpp>
 #include <cstdlib>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 namespace fs = boost::process::v1::filesystem;
 
 

--- a/test/v1/env.cpp
+++ b/test/v1/env.cpp
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <list>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(inherit_env, *boost::unit_test::timeout(2))
 {

--- a/test/v1/environment.cpp
+++ b/test/v1/environment.cpp
@@ -12,7 +12,7 @@
 #include <boost/test/included/unit_test.hpp>
 #include <boost/process/v1/environment.hpp>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 namespace std

--- a/test/v1/error.cpp
+++ b/test/v1/error.cpp
@@ -19,7 +19,7 @@
 
 
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 struct err_set
 {

--- a/test/v1/exit_code.cpp
+++ b/test/v1/exit_code.cpp
@@ -26,7 +26,7 @@ typedef boost::asio::windows::stream_handle pipe_end;
 typedef boost::asio::posix::stream_descriptor pipe_end;
 #endif
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(sync_wait, *boost::unit_test::timeout(10))
 {

--- a/test/v1/extensions.cpp
+++ b/test/v1/extensions.cpp
@@ -17,7 +17,7 @@
 #include <boost/process/v1/extend.hpp>
 
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 struct run_exe

--- a/test/v1/group.cpp
+++ b/test/v1/group.cpp
@@ -29,7 +29,7 @@
 #include <iostream>
 #include <cstdlib>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(group_test, *boost::unit_test::timeout(5))
 {

--- a/test/v1/group_wait.cpp
+++ b/test/v1/group_wait.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <cstdlib>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 

--- a/test/v1/limit_fd.cpp
+++ b/test/v1/limit_fd.cpp
@@ -7,9 +7,7 @@
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
 
-#include <iostream>
-
-#include <boost/process.hpp>
+#include <boost/process/v1/system.hpp>
 #include <boost/process/v1/handles.hpp>
 #include <boost/process/v1/pipe.hpp>
 #include <boost/process/v1/io.hpp>
@@ -32,8 +30,7 @@
 #include <dirent.h>
 #endif
 
-namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 namespace bt = boost::this_process;
 
 BOOST_AUTO_TEST_CASE(leak_test, *boost::unit_test::timeout(5))

--- a/test/v1/multi_ref1.cpp
+++ b/test/v1/multi_ref1.cpp
@@ -4,4 +4,32 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
-#include <boost/process.hpp>
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/async_pipe.hpp>
+#include <boost/process/v1/async_system.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/env.hpp>
+#include <boost/process/v1/environment.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/exception.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/extend.hpp>
+#include <boost/process/v1/filesystem.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/locale.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/shell.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#include <boost/process/v1/system.hpp>
+
+#if defined(BOOST_POSIX_API)
+#include <boost/process/v1/posix.hpp>
+#else
+#include <boost/process/v1/windows.hpp>
+#endif

--- a/test/v1/multi_ref2.cpp
+++ b/test/v1/multi_ref2.cpp
@@ -3,4 +3,32 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/process.hpp>
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/async_pipe.hpp>
+#include <boost/process/v1/async_system.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/env.hpp>
+#include <boost/process/v1/environment.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/exception.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/extend.hpp>
+#include <boost/process/v1/filesystem.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/locale.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/shell.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#include <boost/process/v1/system.hpp>
+
+#if defined(BOOST_POSIX_API)
+#include <boost/process/v1/posix.hpp>
+#else
+#include <boost/process/v1/windows.hpp>
+#endif

--- a/test/v1/no_ansi_apps.cpp
+++ b/test/v1/no_ansi_apps.cpp
@@ -6,5 +6,30 @@
 #include <boost/system/api_config.hpp>
 #if defined(BOOST_WINDOWS_API)
 #define BOOST_NO_ANSI_APIS 1
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/async_pipe.hpp>
+#include <boost/process/v1/async_system.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/env.hpp>
+#include <boost/process/v1/environment.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/exception.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/extend.hpp>
+#include <boost/process/v1/filesystem.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/locale.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/shell.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#include <boost/process/v1/system.hpp>
+#include <boost/process/v1/windows.hpp>
 #endif
-#include <boost/process.hpp>
+
+int main() {}

--- a/test/v1/on_exit.cpp
+++ b/test/v1/on_exit.cpp
@@ -10,7 +10,8 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
-#include <boost/process.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/child.hpp>
 #include <boost/asio.hpp>
 #include <chrono>
 #include <thread>
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_CASE(single_ios, *boost::unit_test::timeout(6))
         return;
     }
 
-    namespace bp = boost::process;
+    namespace bp = boost::process::v1;
     boost::asio::io_context ios;
     std::chrono::steady_clock::time_point p1, p2;
 

--- a/test/v1/on_exit2.cpp
+++ b/test/v1/on_exit2.cpp
@@ -10,7 +10,8 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
-#include <boost/process.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/child.hpp>
 #include <boost/asio.hpp>
 #include <chrono>
 #include <thread>
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_CASE(double_ios, *boost::unit_test::timeout(6))
         return;
     }
 
-    namespace bp = boost::process;
+    namespace bp = boost::process::v1;
     boost::asio::io_context ios;
     std::chrono::steady_clock::time_point p1, p2;
 

--- a/test/v1/on_exit3.cpp
+++ b/test/v1/on_exit3.cpp
@@ -10,7 +10,8 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
-#include <boost/process.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/child.hpp>
 #include <boost/asio.hpp>
 #include <chrono>
 #include <thread>
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_CASE(double_ios_threaded, *boost::unit_test::timeout(6))
         return;
     }
 
-    namespace bp = boost::process;
+    namespace bp = boost::process::v1;
     boost::asio::io_context ios;
     std::chrono::steady_clock::time_point p1, p2;
 

--- a/test/v1/pipe.cpp
+++ b/test/v1/pipe.cpp
@@ -14,7 +14,7 @@
 #include <boost/process/v1/environment.hpp>
 
 using namespace std;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_SUITE( pipe_tests );
 

--- a/test/v1/pipe_fwd.cpp
+++ b/test/v1/pipe_fwd.cpp
@@ -29,7 +29,7 @@
 
 BOOST_AUTO_TEST_SUITE( pipe_tests );
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(sync_io, *boost::unit_test::timeout(5))
 {

--- a/test/v1/posix_specific.cpp
+++ b/test/v1/posix_specific.cpp
@@ -11,10 +11,14 @@
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
 
-#include <boost/process.hpp>
-#include <boost/process/v1/posix.hpp>
-
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/environment.hpp>
 #include <boost/process/v1/filesystem.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/posix.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/system.hpp>
 
 #if !defined(BOOST_PROCESS_USE_STD_FS)
 #include <boost/filesystem/directory.hpp>
@@ -29,7 +33,7 @@
 #include <errno.h>
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(bind_fd, *boost::unit_test::timeout(2))
 {

--- a/test/v1/run_exe.cpp
+++ b/test/v1/run_exe.cpp
@@ -15,7 +15,7 @@
 #include <boost/process/v1/error.hpp>
 #include <boost/process/v1/child.hpp>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 int main(int argc, char* argv[])
 {

--- a/test/v1/run_exe_path.cpp
+++ b/test/v1/run_exe_path.cpp
@@ -18,7 +18,7 @@
 #include <boost/process/v1/error.hpp>
 #include <boost/process/v1/child.hpp>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 BOOST_AUTO_TEST_CASE(run_exe_success)

--- a/test/v1/search_path.cpp
+++ b/test/v1/search_path.cpp
@@ -13,7 +13,7 @@
 #include <boost/process/v1/filesystem.hpp>
 #include <string>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 namespace fs = boost::process::v1::filesystem;
 
 BOOST_AUTO_TEST_CASE(search_path)

--- a/test/v1/shell.cpp
+++ b/test/v1/shell.cpp
@@ -22,7 +22,7 @@
 #include <boost/process/v1/child.hpp>
 #include <boost/process/v1/shell.hpp>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 BOOST_AUTO_TEST_CASE(shell_simple, *boost::unit_test::timeout(5))

--- a/test/v1/shell_path.cpp
+++ b/test/v1/shell_path.cpp
@@ -13,7 +13,7 @@
 #include <boost/process/v1/filesystem.hpp>
 #include <system_error>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(shell_set_on_error)
 {

--- a/test/v1/spawn.cpp
+++ b/test/v1/spawn.cpp
@@ -39,7 +39,7 @@ typedef boost::asio::posix::stream_descriptor pipe_end;
 #endif
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(sync_spawn, *boost::unit_test::timeout(5))
 {

--- a/test/v1/spawn_fail.cpp
+++ b/test/v1/spawn_fail.cpp
@@ -35,7 +35,7 @@ typedef boost::asio::posix::stream_descriptor pipe_end;
 #endif
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 int main()
 {

--- a/test/v1/start_dir.cpp
+++ b/test/v1/start_dir.cpp
@@ -10,14 +10,19 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
-#include <boost/process.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/exe.hpp>
 #include <boost/process/v1/filesystem.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/start_dir.hpp>
 #include <boost/algorithm/string/compare.hpp>
-#include <string>
-#include <iostream>
 
-namespace bp  = boost::process;
+#include <string>
+
+namespace bp = boost::process::v1;
 
 
 struct test_dir

--- a/test/v1/sub_launcher.cpp
+++ b/test/v1/sub_launcher.cpp
@@ -2,7 +2,9 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/process.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/group.hpp>
 #include <boost/program_options.hpp>
 
 #include <vector>
@@ -20,7 +22,7 @@ int main(int argc, char *argv[])
 {
     using namespace std;
     using namespace boost::program_options;
-    using namespace boost::process;
+    using namespace boost::process::v1;
 
     bool launch_detached = false;
     bool launch_attached = false;

--- a/test/v1/system_test1.cpp
+++ b/test/v1/system_test1.cpp
@@ -44,7 +44,7 @@ typedef boost::asio::posix::stream_descriptor pipe_end;
 #endif
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(system_exit_code, *boost::unit_test::timeout(5))
 {

--- a/test/v1/system_test2.cpp
+++ b/test/v1/system_test2.cpp
@@ -38,7 +38,7 @@
 #include <cstdlib>
 
 namespace fs = boost::process::v1::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(explicit_async_io, *boost::unit_test::timeout(2))
 {

--- a/test/v1/terminate.cpp
+++ b/test/v1/terminate.cpp
@@ -20,7 +20,7 @@
 #include <system_error>
 #include <thread>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(terminate_set_on_error, *boost::unit_test::timeout(5))
 {

--- a/test/v1/throw_on_error.cpp
+++ b/test/v1/throw_on_error.cpp
@@ -9,11 +9,11 @@
 
 #include <boost/core/lightweight_test.hpp>
 
-#include <boost/process.hpp>
+#include <boost/process/v1/child.hpp>
 #include <boost/process/v1/cmd.hpp>
 #include <system_error>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 int main(int argc, char* argv[])
 {

--- a/test/v1/vfork.cpp
+++ b/test/v1/vfork.cpp
@@ -11,7 +11,7 @@
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
 
-#include <boost/process.hpp>
+#include <boost/process/v1.hpp>
 #include <boost/process/v1/posix.hpp>
 
 #include <system_error>
@@ -21,7 +21,7 @@
 #include <sys/wait.h>
 #include <errno.h>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 #if defined(BOOST_POSIX_HAS_VFORK)
 

--- a/test/v1/wait.cpp
+++ b/test/v1/wait.cpp
@@ -22,7 +22,7 @@
 #   include <signal.h>
 #endif
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_SUITE( wait_test );
 

--- a/test/v1/wait_for.cpp
+++ b/test/v1/wait_for.cpp
@@ -21,7 +21,7 @@
 #   include <signal.h>
 #endif
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 BOOST_AUTO_TEST_SUITE( wait_test);
 
 BOOST_AUTO_TEST_CASE(wait_for)

--- a/test/v1/wargs_cmd.cpp
+++ b/test/v1/wargs_cmd.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 
 BOOST_AUTO_TEST_CASE(wargs, *boost::unit_test::timeout(2))

--- a/test/v1/windows_specific.cpp
+++ b/test/v1/windows_specific.cpp
@@ -10,14 +10,14 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_IGNORE_SIGCHLD
 #include <boost/test/included/unit_test.hpp>
-#include <boost/process.hpp>
+#include <boost/process/v1.hpp>
 #include <boost/process/v1/windows.hpp>
 #include <boost/process/v1/extend.hpp>
 #include <boost/system/error_code.hpp>
 
 #include <string>
 
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 BOOST_AUTO_TEST_CASE(show_window)
 {


### PR DESCRIPTION
As of 2ccd97cd48, v2 is the default when using the unversioned includes. While working on #449, I noticed that this broke the v1 tests which were still using them.

I'm not sure what the plan is for the v1 tests. I've seen that they have been disabled in the Jamfile https://github.com/boostorg/process/blob/b529769eb5d08d9f95b0130fd2f1a49acad330f4/test/Jamfile.jam#L6-L7
so I assume that is intentional? At the same time, the CMake project still includes the v1 subdirectory:
https://github.com/boostorg/process/blob/b529769eb5d08d9f95b0130fd2f1a49acad330f4/test/CMakeLists.txt#L2-L3
I don't know if the two build systems are manually kept in sync and this was an oversight, or if there's tooling to regenerate the CMake files at some point?

Anyway, I would advocate either reinstating the v1 tests (in which case I hope that this PR saves you some time), or deleting them altogether, including from the CMake file.