### PR TITLE
Remove optional dependency on filesystem when not meant to be

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ target_link_libraries(boost_process
     Boost::asio
     Boost::config
     Boost::core
-    Boost::filesystem
     Boost::fusion
     Boost::iterator
     Boost::move


### PR DESCRIPTION
Build previously failed when BOOST_PROCESS_USE_STD_FS was ON, because filesystem was linked to regardless.

I tried to use this library with the std version of filesystem and I noticed that Boost::filesystem was listed as a dependency regardless of the flag. I'm pretty sure this is just a little mistake.