### PR TITLE
Fix wide strings conversion on POSIX

### DIFF
--- a/include/boost/process/v1/locale.hpp
+++ b/include/boost/process/v1/locale.hpp
@@ -78,8 +78,9 @@ inline std::locale default_locale()
     std::locale global_loc = std::locale();
     return std::locale(global_loc, new std::codecvt_utf8<wchar_t>);
 # else  // Other POSIX
-    // Return a default locale object.
-    return std::locale();
+    // ISO C calls std::locale("") "the locale-specific native environment", and this
+    // locale is the default for many POSIX-based operating systems such as Linux.
+    return std::locale("");
 # endif
 }
 


### PR DESCRIPTION
This commit effectively reverts #179 which shouldn't have been merged in the first place. See https://github.com/boostorg/filesystem/pull/163#issuecomment-786794483 for explanation.

For example, this code https://godbolt.org/z/rdvxh1EPz throws the following exception:
```c++
boost::process codecvt to char: error
```

Workaround is to manually call `boost::process::imbue` with the correct locale:
```c++
boost::process::imbue(std::locale(""));
```