### PR TITLE
Remove Ubuntu 20.04 builds from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,19 +23,19 @@ jobs:
         include:
           - { toolset: gcc-5,                        cxxstd: "11,14,1z",       os: ubuntu-latest, container: 'ubuntu:18.04', install: g++-5 }
           - { toolset: gcc-6,                        cxxstd: "11,14,1z",       os: ubuntu-latest, container: 'ubuntu:18.04', install: g++-6 }
-          - { toolset: gcc-7,                        cxxstd: "11,14,17",       os: ubuntu-20.04, install: g++-7 }
+          - { toolset: gcc-7,                        cxxstd: "11,14,17",       os: ubuntu-latest, container: 'ubuntu:20.04', install: g++-7 }
           - { toolset: gcc-10,                       cxxstd: "11,14,17,2a",    os: ubuntu-22.04, install: g++-10 }
           - { toolset: gcc-12,                       cxxstd: "11,14,17,20,2b", os: ubuntu-22.04, install: g++-12 }
           - { toolset: clang, compiler: clang++-3.9, cxxstd: "11,14",          os: ubuntu-latest, container: 'ubuntu:18.04', install: clang-3.9 }
           - { toolset: clang, compiler: clang++-4.0, cxxstd: "11,14",          os: ubuntu-latest, container: 'ubuntu:18.04', install: clang-4.0 }
           - { toolset: clang, compiler: clang++-5.0, cxxstd: "11,14,1z",       os: ubuntu-latest, container: 'ubuntu:18.04', install: clang-5.0 }
-          - { toolset: clang, compiler: clang++-6.0, cxxstd: "11,14,17",       os: ubuntu-20.04, install: clang-6.0 }
-          - { toolset: clang, compiler: clang++-7,   cxxstd: "11,14,17",       os: ubuntu-20.04, install: clang-7 }
-          - { toolset: clang, compiler: clang++-8,   cxxstd: "11,14,17",       os: ubuntu-20.04, install: clang-8 }
-          - { toolset: clang, compiler: clang++-9,   cxxstd: "11,14,17,2a",    os: ubuntu-20.04, install: clang-9 }
-          - { toolset: clang, compiler: clang++-10,  cxxstd: "11,14,17,2a",    os: ubuntu-20.04, install: clang-10 }
-          - { toolset: clang, compiler: clang++-11,  cxxstd: "11,14,17,2a",    os: ubuntu-20.04, install: clang-11 }
-          - { toolset: clang, compiler: clang++-12,  cxxstd: "11,14,17,2a",    os: ubuntu-20.04, install: clang-12 }
+          - { toolset: clang, compiler: clang++-6.0, cxxstd: "11,14,17",       os: ubuntu-latest, container: 'ubuntu:20.04', install: clang-6.0 }
+          - { toolset: clang, compiler: clang++-7,   cxxstd: "11,14,17",       os: ubuntu-latest, container: 'ubuntu:20.04', install: clang-7 }
+          - { toolset: clang, compiler: clang++-8,   cxxstd: "11,14,17",       os: ubuntu-latest, container: 'ubuntu:20.04', install: clang-8 }
+          - { toolset: clang, compiler: clang++-9,   cxxstd: "11,14,17,2a",    os: ubuntu-latest, container: 'ubuntu:20.04', install: clang-9 }
+          - { toolset: clang, compiler: clang++-10,  cxxstd: "11,14,17,2a",    os: ubuntu-latest, container: 'ubuntu:20.04', install: clang-10 }
+          - { toolset: clang, compiler: clang++-11,  cxxstd: "11,14,17,2a",    os: ubuntu-22.04, install: clang-11 }
+          - { toolset: clang, compiler: clang++-12,  cxxstd: "11,14,17,2a",    os: ubuntu-22.04, install: clang-12 }
           - { toolset: clang, compiler: clang++-13,  cxxstd: "11,14,17,20,2b", os: ubuntu-22.04, install: clang-13 }
           - { toolset: clang, compiler: clang++-14,  cxxstd: "11,14,17,20,2b", os: ubuntu-22.04, install: clang-14 }
           - { toolset: clang,                        cxxstd: "11,14,17,2a",    os: macos-13 }


### PR DESCRIPTION
The Ubuntu 20.04 image on GitHub Actions has been unavailable since 2025-04-15. See <https://github.com/actions/runner-images/issues/11101> for more information on the deprecation and removal.

Therefore all build jobs that use the Ubuntu 20.04 runner image of GHA will fail and have to be replaced by newer images or have to move into Ubuntu 20.04 containers.