### PR TITLE
test/v2: Resolve cmake link error regarding init_unit_test_suite

### DIFF
--- a/test/v2/cstring_ref.cpp
+++ b/test/v2/cstring_ref.cpp
@@ -3,6 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_TEST_MAIN
 
 // Disable autolinking for unit tests.
 #if !defined(BOOST_ALL_NO_LIB)

--- a/test/v2/environment.cpp
+++ b/test/v2/environment.cpp
@@ -3,6 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_TEST_MAIN
 
 // Disable autolinking for unit tests.
 #if !defined(BOOST_ALL_NO_LIB)

--- a/test/v2/ext.cpp
+++ b/test/v2/ext.cpp
@@ -4,6 +4,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_TEST_MAIN
+
 #include <boost/process/v2/ext/cmd.hpp>
 #include <boost/process/v2/ext/cwd.hpp>
 #include <boost/process/v2/ext/env.hpp>

--- a/test/v2/pid.cpp
+++ b/test/v2/pid.cpp
@@ -4,6 +4,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_TEST_MAIN
+
 #include <boost/process/v2/pid.hpp>
 #include <boost/process/v2/process.hpp>
 

--- a/test/v2/process.cpp
+++ b/test/v2/process.cpp
@@ -3,6 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_TEST_MAIN
 
 // Disable autolinking for unit tests.
 #if !defined(BOOST_ALL_NO_LIB)

--- a/test/v2/shell.cpp
+++ b/test/v2/shell.cpp
@@ -3,6 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_TEST_MAIN
+
 // Disable autolinking for unit tests.
 #if !defined(BOOST_ALL_NO_LIB)
 #define BOOST_ALL_NO_LIB 1

--- a/test/v2/utf8.cpp
+++ b/test/v2/utf8.cpp
@@ -3,6 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_TEST_MAIN
+
 // Disable autolinking for unit tests.
 #if !defined(BOOST_ALL_NO_LIB)
 #define BOOST_ALL_NO_LIB 1


### PR DESCRIPTION
Fix for [boostorg/boost Issue #1033](https://github.com/boostorg/boost/issues/1033)

I'd come across a problem building boost 1.89.0 on Ubuntu 24.04 (Noble) in `-DBUILD_TESTING=Y` mode.
Turned out the same had been reported previously as mentioned above.

This change resolves the problem for me, seems like the same as being done for `test/v1` tests.

Working build for [boostorg/boost](https://github.com/boostorg/boost)

```
cmake .. --fresh -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=Y && ninja
```
