### PR TITLE
Fix compilation on Windows with BOOST_PROCESS_STANDALONE defined

### DIFF
--- a/include/boost/process/v2/detail/config.hpp
+++ b/include/boost/process/v2/detail/config.hpp
@@ -102,7 +102,11 @@ using std::optional;
 
 #define BOOST_PROCESS_V2_ASSIGN_EC(ec, ...) ec.assign(__VA_ARGS__);
 #define BOOST_PROCESS_V2_ASSIGN_LAST_ERROR(ec)                         \
-  ec.assign(::BOOST_PROCESS_V2_NAMESPACE::detail::get_last_error());   \
+do                                                                     \
+{                                                                      \
+  ec = ::BOOST_PROCESS_V2_NAMESPACE::detail::get_last_error();         \
+}                                                                      \
+while (false)
 
 
 #else
@@ -157,7 +161,7 @@ BOOST_PROCESS_V2_END_NAMESPACE
 #define BOOST_DYN_LINK
 #endif
 #include <boost/config/auto_link.hpp>
-#endif 
+#endif
 
 #if defined(BOOST_PROCESS_V2_POSIX)
 

--- a/include/boost/process/v2/process.hpp
+++ b/include/boost/process/v2/process.hpp
@@ -165,7 +165,7 @@ struct basic_process
   template <typename ExecutionContext>
   explicit basic_process(ExecutionContext & context,
                          typename std::enable_if<
-                             is_convertible<ExecutionContext&, 
+                            std::is_convertible<ExecutionContext&, 
                                 net::execution_context&>::value, void *>::type = nullptr)
      : process_handle_(context.get_executor()) {}
 

--- a/include/boost/process/v2/windows/default_launcher.hpp
+++ b/include/boost/process/v2/windows/default_launcher.hpp
@@ -250,7 +250,7 @@ struct default_launcher
       auto proc =  (*this)(context, ec, executable, std::forward<Args>(args), std::forward<Inits>(inits)...);
 
       if (ec)
-          v2::detail::throw_error(ec, "default_launcher");
+          detail::throw_error(ec, "default_launcher");
 
       return proc;
   }


### PR DESCRIPTION
While trying to use Boost.Process with the non-Boost standalone Asio, I found that some of the code in Boost.Process failed to compile when defining `BOOST_PROCESS_STANDALONE`, `BOOST_PROCESS_V2_STANDALONE` and `BOOST_PROCESS_USE_STD_FS`.

These fixes address the issues raised in https://github.com/boostorg/process/issues/535.