### PR TITLE
Replace the dependency on asio with asio_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(boost_process PUBLIC include)
 target_link_libraries(boost_process
     PUBLIC
     Boost::algorithm
-    Boost::asio
+    Boost::asio_core
     Boost::config
     Boost::core
     Boost::fusion

--- a/build.jam
+++ b/build.jam
@@ -12,7 +12,7 @@ feature boost.process.disable-close-range : on off : optional ;
 
 constant boost_dependencies :
     /boost/algorithm//boost_algorithm
-    /boost/asio//boost_asio
+    /boost/asio//boost_asio_core
     /boost/assert//boost_assert
     /boost/config//boost_config
     /boost/core//boost_core


### PR DESCRIPTION
Boost.Process doesn't use any advanced Boost.ASIO features and switching to asio_core removes the transitive dependencies on Boost.Context and Boost.DateTime.