### PR TITLE
Fix tuple helper classes

### DIFF
--- a/include/boost/process/v2/environment.hpp
+++ b/include/boost/process/v2/environment.hpp
@@ -1253,19 +1253,17 @@ namespace std
 {
 
 template<>
-class tuple_size<BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair> : integral_constant<std::size_t, 2u> {};
+struct tuple_size<BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair> : integral_constant<std::size_t, 2u> {};
 
 template<>
-class tuple_element<0u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair> 
+struct tuple_element<0u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair> 
 {
-  public: 
     using type = BOOST_PROCESS_V2_NAMESPACE::environment::key_view;
 };
 
 template<>
-class tuple_element<1u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair> 
+struct tuple_element<1u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair> 
 {
-  public: 
     using type = BOOST_PROCESS_V2_NAMESPACE::environment::value_view;
 };
 
@@ -1277,19 +1275,17 @@ inline auto get(const BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair & 
 }
 
 template<>
-class tuple_size<BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair_view> : integral_constant<std::size_t, 2u> {};
+struct tuple_size<BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair_view> : integral_constant<std::size_t, 2u> {};
 
 template<>
-class tuple_element<0u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair_view>
+struct tuple_element<0u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair_view>
 {
-  public:
     using type = BOOST_PROCESS_V2_NAMESPACE::environment::key_view;
 };
 
 template<>
-class tuple_element<1u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair_view>
+struct tuple_element<1u, BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair_view>
 {
-  public:
     using type = BOOST_PROCESS_V2_NAMESPACE::environment::value_view;
 };
 


### PR DESCRIPTION
clang 19.1.5 reported the following error. Because the standard shows the helpers as structs, converted them all to structs instead of classes and removed unnecessary public visibility specifier.
```
Boost/libs/process/include/boost/process/v2/environment.hpp:1280:82: note: constrained by implicitly private inheritance here
  1280 | class tuple_size<BOOST_PROCESS_V2_NAMESPACE::environment::key_value_pair_view> : integral_constant<std::size_t, 2u> {};
       |                                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /opt/gcc-15.1/bin/../lib/gcc/x86_64-pc-linux-gnu/15/../../../../include/c++/15/type_traits:94:28: note: member is declared here
    94 |       static constexpr _Tp value = __v;
       |                            ^
```