### PR TITLE
fix: remove noexcept from function which may throw

### DIFF
--- a/include/boost/process/v1/detail/posix/wait_group.hpp
+++ b/include/boost/process/v1/detail/posix/wait_group.hpp
@@ -45,7 +45,7 @@ inline void wait(const group_handle &p, std::error_code &ec) noexcept
         ec.clear();
 }
 
-inline void wait(const group_handle &p) noexcept
+inline void wait(const group_handle &p)
 {
     std::error_code ec;
     wait(p, ec);


### PR DESCRIPTION
wait(const group_handle &p) is the throwing version, should not be marked noexcept.