### PR TITLE
Fix program hang by closing pipe in the parent process

### DIFF
--- a/include/boost/process/v2/stdio.hpp
+++ b/include/boost/process/v2/stdio.hpp
@@ -173,10 +173,18 @@ struct process_io_binding
   bool fd_needs_closing{false};
   error_code ec;
 
-  ~process_io_binding()
+  void close()
   {
     if (fd_needs_closing)
+    {
       ::close(fd);
+      fd = target;
+      fd_needs_closing = false;
+    }
+  }
+  ~process_io_binding()
+  {
+    close();
   }
 
   process_io_binding() = default;
@@ -193,8 +201,7 @@ struct process_io_binding
 
   process_io_binding & operator=(process_io_binding && other) noexcept
   {
-    if (fd_needs_closing)
-      ::close(fd);
+    close();
 
     fd = other.fd;
     fd_needs_closing = other.fd_needs_closing;
@@ -357,6 +364,22 @@ struct process_stdio
       return error_code(errno, system_category());
 
     return error_code {};
+  };
+
+  // weather fork succeeded or not, we should close the pipe properly in the parent
+  void close_pipes()
+  {
+    in.close();
+    out.close();
+    err.close();
+  };
+  void on_success(posix::default_launcher & /*launcher*/, const filesystem::path &, const char * const *)
+  {
+    close_pipes();
+  };
+  void on_error(posix::default_launcher & /*launcher*/, const filesystem::path &, const char * const *)
+  {
+    close_pipes();
   };
 #endif
 


### PR DESCRIPTION
Before this patch, pipe file descriptors were not properly closed after `fork` was called. This causes the program to hang infinitely under specific conditions.

The following code could be used to reproduce the issue:
```C++
# include <boost/process.hpp>
# include <boost/asio.hpp>
# include <iostream>
# include <format>

int main()
{
  namespace bp = boost::process;
  boost::asio::io_context context;
  boost::filesystem::path actual_program = bp::environment::find_executable("echo");
  auto env = bp::environment::current();
  auto stdout_pipe = std::make_unique<boost::asio::readable_pipe>(context);
  std::string stdout_string;
  bp::process_stdio stdio{ .in = {}, .out = *stdout_pipe, .err = {} };
  auto proc = bp::process
    (context, actual_program, { "hhh" }, std::move(stdio), std::move(env));
  proc.wait();
  boost::system::error_code ec;
  boost::asio::read(*stdout_pipe, boost::asio::dynamic_buffer(stdout_string), ec);
  std::cout << std::format("{} {}\n", proc.exit_code(), stdout_string);
}
```

Compile the code with pidfd disabled (either by setting the `BOOST_PROCESS_V2_DISABLE_PIDFD_OPEN` macro or by using an old kernel header like 3.10), the program will hang after starting.

`strace` gives:
```
wait4(1763335, 0x7ffe3342ebc0, WNOHANG, NULL) = 0
wait4(1763335, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 1763335
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=1763335, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
write(9, "\21\0\0\0", 4)                = 4
rt_sigreturn({mask=[]})                 = 1763335
read(6, "hhh\n", 512)                   = 4
read(6
```

As shown in the strace output, the child process successfully exits, but the parent process blocks indefinitely on read(6). The root cause is that the **writing-end** of the pipe (fd 7) is still open in the parent process, even it has been closed in the child process (since the child process have died) and should never be used in the parent process. This make the read operation on reading-end of the pipe (fd 6) remains blocked waiting for EOF.