### PR TITLE
Add GNU/Hurd Support to `cwd()`/`exe()`

### DIFF
--- a/src/ext/cwd.cpp
+++ b/src/ext/cwd.cpp
@@ -31,7 +31,7 @@
 #endif
 #endif
 
-#if (defined(BOOST_PROCESS_V2_WINDOWS) || defined(__linux__) || defined(__ANDROID__) || defined(__sun))
+#if (defined(BOOST_PROCESS_V2_WINDOWS) || defined(__linux__) || defined(__ANDROID__) || defined(__gnu_hurd__) || defined(__sun))
 #include <cstdlib>
 #endif
 
@@ -115,11 +115,11 @@ filesystem::path cwd(boost::process::v2::pid_type pid, error_code & ec)
     return "";
 }
 
-#elif (defined(__linux__) || defined(__ANDROID__) || defined(__sun))
+#elif (defined(__linux__) || defined(__ANDROID__) || defined(__gnu_hurd__) || defined(__sun))
 
 filesystem::path cwd(boost::process::v2::pid_type pid, error_code & ec)
 {
-#if (defined(__linux__) || defined(__ANDROID__))
+#if (defined(__linux__) || defined(__ANDROID__) || defined(__gnu_hurd__))
     return filesystem::canonical(
             filesystem::path("/proc") / std::to_string(pid) / "cwd", ec
             );

--- a/src/ext/exe.cpp
+++ b/src/ext/exe.cpp
@@ -32,7 +32,7 @@
 #endif
 #endif
 
-#if (defined(BOOST_PROCESS_V2_WINDOWS) || defined(__linux__) || defined(__ANDROID__) || defined(__sun))
+#if (defined(BOOST_PROCESS_V2_WINDOWS) || defined(__linux__) || defined(__ANDROID__) || defined(__gnu_hurd__) || defined(__sun))
 #include <cstdlib>
 #endif
 
@@ -132,11 +132,11 @@ filesystem::path exe(boost::process::v2::pid_type pid, error_code & ec)
     return "";
 }
 
-#elif (defined(__linux__) || defined(__ANDROID__) || defined(__sun))
+#elif (defined(__linux__) || defined(__ANDROID__) || defined(__gnu_hurd__) || defined(__sun))
 
 filesystem::path exe(boost::process::v2::pid_type pid, error_code & ec)
 {
-#if (defined(__linux__) || defined(__ANDROID__))
+#if (defined(__linux__) || defined(__ANDROID__) || defined(__gnu_hurd__))
     return filesystem::canonical(
             filesystem::path("/proc") / std::to_string(pid) / "exe", ec
             );


### PR DESCRIPTION
The `/proc` filesystem approach will only work in more recent versions of GNU/Hurd. There are ways to do it on this platform even when the `/proc` filesystem isn't mounted, good for use as a fallback solution, but I don't feel like adding that right now.