### PR TITLE
guard WideCharToMultiByte() against empty strings

### DIFF
--- a/src/detail/utf8.cpp
+++ b/src/detail/utf8.cpp
@@ -37,6 +37,8 @@ inline void handle_error(error_code & ec)
 
 std::size_t size_as_utf8(const wchar_t * in, std::size_t size, error_code & ec)
 {
+    if (size == 0u)
+        return 0u;
     auto res = WideCharToMultiByte(
                           CP_UTF8,                // CodePage,
                           0,                      // dwFlags,
@@ -72,6 +74,8 @@ std::size_t size_as_wide(const char * in, std::size_t size, error_code & ec)
 std::size_t convert_to_utf8(const wchar_t *in, std::size_t size,  char * out, 
                             std::size_t max_size, error_code & ec)
 {
+    if (size == 0u)
+        return 0u;
     auto res = ::WideCharToMultiByte(
                     CP_UTF8,                    // CodePage
                     0,                          // dwFlags


### PR DESCRIPTION
This should fix <https://github.com/boostorg/process/issues/554>.

The Windows API function [`WideCharToMultiByte()`](https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte) fails, when its `cchWideChar` parameter is set to zero. Therefore, a check for size of zero is introduced to avoid that. Similar to commit f372a9a119b27a1a15683e6fbe945f83f5c4ef54, as suggested by @aliquis162 in https://github.com/boostorg/process/issues/554#issue-4358252860.