### PR TITLE
[bugfix] iOS: wordexp/wordfree unavailable and missing env() implementation

### DIFF
--- a/src/ext/env.cpp
+++ b/src/ext/env.cpp
@@ -309,6 +309,14 @@ env_view env(boost::process::v2::pid_type pid, error_code & ec)
     return ev;
 }
 
+#elif defined(__APPLE__) && defined(__MACH__) && TARGET_OS_IOS
+
+env_view env(boost::process::v2::pid_type pid, error_code & ec)
+{
+    BOOST_PROCESS_V2_ASSIGN_EC(ec, ENOTSUP, system_category());
+    return {};
+}
+
 #elif (defined(__linux__) || defined(__ANDROID__)) || defined(__gnu_hurd__)
 
 env_view env(boost::process::v2::pid_type pid, error_code & ec)

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -16,10 +16,14 @@
 #include <boost/process/v2/error.hpp>
 #include <boost/process/v2/shell.hpp>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 #if defined(BOOST_PROCESS_V2_WINDOWS)
 #include <windows.h>
 #include <shellapi.h>
-#elif !defined(__OpenBSD__) && !defined(__ANDROID__)
+#elif !defined(__OpenBSD__) && !defined(__ANDROID__) && !(defined(__APPLE__) && !TARGET_OS_OSX)
 #include <wordexp.h>
 #endif
 
@@ -30,7 +34,7 @@ BOOST_PROCESS_V2_DECL const error_category& get_shell_category()
 {
     return system_category();
 }
-#elif !defined(__OpenBSD__) && !defined(__ANDROID__)
+#elif !defined(__OpenBSD__) && !defined(__ANDROID__) && !(defined(__APPLE__) && !TARGET_OS_OSX)
 
 struct shell_category_t final : public error_category
 {
@@ -99,7 +103,7 @@ auto shell::args() const-> args_type
     return input_.c_str();
 }
 
-#elif !defined(__OpenBSD__) && !defined(__ANDROID__)
+#elif !defined(__OpenBSD__) && !defined(__ANDROID__) && !(defined(__APPLE__) && !TARGET_OS_OSX)
 
 void shell::parse_()
 {


### PR DESCRIPTION
Greetings! 👋 

When building Boost 1.91.0 on Mac M1 (aarch64) for iOS with Apple clang, it fails to build Boost.Process with two independent errors:

### 1. The functions `wordexp` and `wordfree` are unavailable on iOS

Apple iOS/tvOS/watchOS SDKs ship `<wordexp.h>` (inherited from the shared Apple SDK headers), but explicitly mark `wordexp()`/`wordfree()` as unavailable there:

```
    libs/process/src/shell.cpp:107:15: error: 'wordexp' is unavailable: not available on iOS
      107 |     auto cd = wordexp(input_.c_str(), &we, WRDE_NOCMD);
          |               ^
    .../iPhoneOS26.5.sdk/usr/include/wordexp.h:84:5: note: 'wordexp' has been
    explicitly marked unavailable here
       84 | int wordexp(const char * __restrict, wordexp_t * __restrict, int) __OSX_AVAILABLE_STARTING(__MAC_10_0, __IPHONE_NA);
    libs/process/src/shell.cpp:124:9: error: 'wordfree' is unavailable: not available on iOS
    2 errors generated.
```

The full build error can be seen here: [boost-1.91.0-ios-shared-process-wordexp.log](https://github.com/user-attachments/files/30005012/boost-1.91.0-ios-shared-process-wordexp.log)

The `shell.cpp` already guards against `__OpenBSD__` and `__ANDROID__`

https://github.com/boostorg/process/blob/boost-1.91.0/src/shell.cpp#L22

```cpp
#elif !defined(__OpenBSD__) && !defined(__ANDROID__)
#include <wordexp.h>
#endif
```

Similar to #440, it's just missing the same guard for Apple's non-macOS targets like `iphone`. 

The commit ecca6b2307f275d928de02a1b164146c2b8818cb extends that rule to include Apple platforms that are not `darwin`. We need to include `TargetConditionals.h` to make `TARGET_OS_OSX` available.

Reference: https://developer.apple.com/documentation/xcode/running-code-on-a-specific-version#Compile-code-for-a-specific-platform

### 2. Function `ext::env` is never defined for iOS

Once the commit ecca6b2307f275d928de02a1b164146c2b8818cb is applied, the previously mentioned error no longer occurs, but a new error shows later during the linkage stage:

```
	Undefined symbols for architecture arm64:
	  "boost::process::v2::ext::env(int, boost::system::error_code&)", referenced from:
	      boost::process::v2::ext::env(int) in env.o
	ld: symbol(s) not found for architecture arm64
```

You can see the build log with this error here: [boost-1.91.0-ios-shared-process-env.log](https://github.com/user-attachments/files/30005232/boost-1.91.0-ios-shared-process-env.log)

The `env.cpp` already correctly excludes iOS with `#elif (defined(__APPLE__) && defined(__MACH__)) && !TARGET_OS_IOS`, but no replacement for `ext::env` was added for the iOS case, so on iOS execution falls through every `#elif` with none matching, the symbols result as undefined.

The commit beec4966b1ca3afc38534044fda0006b60baad9d adds an iOS-specific implementation of `ext::env` that returns `ENOTSUP`, mirroring OpenBSD/Android.

Both changes only affect Apple non-macOS targets; for b2, they are `iphone` and `appletv`. I validated both the `shared` and `static` link variants build on iOS 26.5 / Apple clang 21.0.0 with this patch applied to Boost 1.91.0. You can check my build logs with this patch:
 
* [boost-1.91.0-ios-static-patched.log](https://github.com/user-attachments/files/30005525/boost-1.91.0-ios-static-patched.log)
* [boost-1.91.0-ios-shared-patched.log](https://github.com/user-attachments/files/30005543/boost-1.91.0-ios-shared-patched.log)

#### Steps to Reproduce

```
wget https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2
tar jxf boost_1_91_0.tar.bz2 && cd boost_1_91_0/
./bootstrap.sh
./b2 install --prefix=/tmp/boost-install-ios --user-config=user-config.jam toolset=clang target-os=iphone architecture=arm address-model=64 abi=aapcs link=shared --with-process
```

My `user-config.jam` looks like:

```
using clang : : clang++ :
    <cflags>"-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -arch arm64 -mios-version-min=26.5"
    <cxxflags>"-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -arch arm64 -mios-version-min=26.5"
    <linkflags>"-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -arch arm64 -mios-version-min=26.5" ;
```

#### Environment
- Boost: 1.91.0
- Host OS: macOS 26.5 (arm64)
- Target OS: iOS 26.5
- Compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)


This PR is related to #401.

Feel free to ask for more information about this case if needed. Regards!
